### PR TITLE
add back support for browserify and webpack

### DIFF
--- a/dist/.npmignore
+++ b/dist/.npmignore
@@ -1,2 +1,3 @@
 *
 !csstree.js
+!default-syntax.json


### PR DESCRIPTION
Thanks for a great repository! 

I'm using it at [philschatz/css-plus](https://github.com/philschatz/css-plus) to implement some features in https://www.w3.org/TR/css-content-3/ and https://www.w3.org/TR/css-gcpm-3/ but noticed there is a file missing when building for the browser.

I'm not sure but it seems this could fix it.