### PR TITLE
Extended "position" property with -webkit-sticky

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -197,6 +197,10 @@
       "comment": "extended with -ms-flexbox",
       "syntax": "none | inline | block | list-item | inline-list-item | inline-block | inline-table | table | table-cell | table-column | table-column-group | table-footer-group | table-header-group | table-row | table-row-group | flex | inline-flex | grid | inline-grid | run-in | ruby | ruby-base | ruby-text | ruby-base-container | ruby-text-container | contents | -ms-flexbox | -ms-inline-flexbox | -ms-grid | -ms-inline-grid | -webkit-flex | -webkit-inline-flex | -webkit-box | -webkit-inline-box | -moz-inline-stack | -moz-box | -moz-inline-box"
     },
+    "position": {
+      "comment": "extended with -webkit-sticky",
+      "syntax": "static | relative | absolute | sticky | fixed | -webkit-sticky"
+    },
     "dominant-baseline": {
       "comment": "added SVG property",
       "references": [


### PR DESCRIPTION
`-webkit-sticky` works fine in Safari, see https://developer.mozilla.org/de/docs/Web/CSS/position