### PR TITLE
Fix typo

### DIFF
--- a/lib/utils/list.js
+++ b/lib/utils/list.js
@@ -330,7 +330,7 @@ List.prototype.insert = function(item, before) {
         if (before.prev === null) {
             // insert to the beginning of list
             if (this.head !== before) {
-                throw new Error('before doesn\'t below to list');
+                throw new Error('before doesn\'t belong to list');
             }
 
             // since head points to before therefore list doesn't empty
@@ -364,7 +364,7 @@ List.prototype.remove = function(item) {
         item.prev.next = item.next;
     } else {
         if (this.head !== item) {
-            throw new Error('item doesn\'t below to list');
+            throw new Error('item doesn\'t belong to list');
         }
 
         this.head = item.next;
@@ -374,7 +374,7 @@ List.prototype.remove = function(item) {
         item.next.prev = item.prev;
     } else {
         if (this.tail !== item) {
-            throw new Error('item doesn\'t below to list');
+            throw new Error('item doesn\'t belong to list');
         }
 
         this.tail = item.prev;

--- a/test/list.js
+++ b/test/list.js
@@ -405,12 +405,12 @@ describe('List', function() {
             });
         });
 
-        it('insert head item that doesn\'t below to list', function() {
+        it('insert head item that doesn\'t belong to list', function() {
             var inserted = List.createItem({});
 
             assert.throws(function() {
                 list2.insert(inserted, list1.head);
-            }, /^Error: before doesn't below to list$/);
+            }, /^Error: before doesn't belong to list$/);
         });
     });
 
@@ -457,16 +457,16 @@ describe('List', function() {
             });
         });
 
-        it('remove head item that doesn\'t below to list', function() {
+        it('remove head item that doesn\'t belong to list', function() {
             assert.throws(function() {
                 list1.remove(list2.head);
-            }, /^Error: item doesn't below to list$/);
+            }, /^Error: item doesn't belong to list$/);
         });
 
-        it('remove tail item that doesn\'t below to list', function() {
+        it('remove tail item that doesn\'t belong to list', function() {
             assert.throws(function() {
                 list1.remove(list2.tail);
-            }, /^Error: item doesn't below to list$/);
+            }, /^Error: item doesn't belong to list$/);
         });
     });
 


### PR DESCRIPTION
This PR fixes a typo in List exceptions ("below" -> "belong").

Side note: Not to be confused with a CSS attribute "below" (https://github.com/csstree/csstree/blob/b57db202932d87d4134cbb9527f1612e4caf4c78/data/mdn-data-properties.json#L439)