### PR TITLE
Validate sourcemap

### DIFF
--- a/lib/generator/sourceMap.js
+++ b/lib/generator/sourceMap.js
@@ -44,14 +44,6 @@ module.exports = function generateSourceMap(generator, ast) {
             generated.line = line;
             generated.column = column;
 
-            if (sourceMappingActive) {
-                sourceMappingActive = false;
-                if (generated.line !== activatedGenerated.line ||
-                    generated.column !== activatedGenerated.column) {
-                    map.addMapping(activatedMapping);
-                }
-            }
-
             sourceMappingActive = true;
             map.addMapping({
                 source: node.loc.source,
@@ -66,10 +58,6 @@ module.exports = function generateSourceMap(generator, ast) {
             activatedGenerated.column = column;
         }
     });
-
-    if (sourceMappingActive) {
-        map.addMapping(activatedMapping);
-    }
 
     return {
         css: css,

--- a/lib/syntax/node/Block.js
+++ b/lib/syntax/node/Block.js
@@ -79,13 +79,15 @@ module.exports = {
         };
     },
     generate: function(processChunk, node) {
-        processChunk('{');
+        // Bugfix: Chrome supports sourceMappingURL in <style> tags but each selector needs to be on a new line.
+        // Otherwise, the dev tools only show the last mapping line/column
+        processChunk('{\n');
         this.each(processChunk, node, function(prev) {
             if (prev.type === 'Declaration') {
-                processChunk(';');
+                processChunk(';\n');
             }
         });
-        processChunk('}');
+        processChunk('}\n');
     },
     walkContext: 'block'
 };

--- a/lib/syntax/node/Rule.js
+++ b/lib/syntax/node/Rule.js
@@ -48,6 +48,9 @@ module.exports = {
     generate: function(processChunk, node) {
         this.generate(processChunk, node.prelude);
         this.generate(processChunk, node.block);
+        // Bugfix: Chrome supports sourceMappingURL in <style> tags but each selector needs to be on a new line.
+        // Otherwise, the dev tools only show the last mapping line/column
+        processChunk('\n');
     },
     walkContext: 'rule'
 };


### PR DESCRIPTION
and ensure that `originalLine` and `originalColumn` exist for each mapping.

I noticed that this was a problem when I tried to inspect an HTML file that contained a `<style>` tag with a `/* # sourceMappingURL=... */`.

Example:



