### PR TITLE
Add missing -ms and -moz css properties

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -20,6 +20,10 @@
       "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius",
       "syntax": "<'border-bottom-right-radius'>"
     },
+    "-moz-control-character-visibility": {
+      "comment": "firefox specific keywords, https://bugzilla.mozilla.org/show_bug.cgi?id=947588",
+      "syntax": "visible | hidden"
+    },
     "-moz-osx-font-smoothing": {
       "comment": "misssed old syntax https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth",
       "syntax": "auto | grayscale"

--- a/data/patch.json
+++ b/data/patch.json
@@ -662,15 +662,15 @@
     },
     "track-group": {
       "comment": "used by old grid-columns and grid-rows syntax v0",
-      "syntax": "[ '(' [ [ <string> ]* <track-minmax> [ <string> ]* ]+ ')' [ '[' <positive-integer> ']' ]? | <track-minmax> ]"
+      "syntax": "'(' [ <string>* <track-minmax> <string>* ]+ ')' [ '[' <positive-integer> ']' ]? | <track-minmax>"
     },
     "track-list-v0": {
       "comment": "used by old grid-columns and grid-rows syntax v0",
-      "syntax": "[ [ <string> ]* <track-group> [ <string> ]* ]+ | 'none'"
+      "syntax": "[ <string>* <track-group> <string>* ]+ | none"
     },
     "track-minmax": {
       "comment": "used by old grid-columns and grid-rows syntax v0",
-      "syntax": "'minmax(' <track-breadth> ',' <track-breadth> ')' | 'auto' | <track-breadth> | 'fit-content'"
+      "syntax": "minmax( <track-breadth> , <track-breadth> ) | auto | <track-breadth> | fit-content"
     },
     "x": {
       "comment": "missed; not sure we should add it, but no others except `cursor` is using it so it's ok for now; https://drafts.csswg.org/css-ui-3/#cursor",

--- a/data/patch.json
+++ b/data/patch.json
@@ -72,9 +72,17 @@
       "comment": "add this property first since it uses as fallback for flexbox, https://msdn.microsoft.com/en-us/library/windows/apps/hh466338.aspx",
       "syntax": "start | end | center | stretch"
     },
+    "-ms-grid-columns": {
+      "comment": "misssed old syntax implemented in IE; https://www.w3.org/TR/2012/WD-css3-grid-layout-20120322/#grid-columns",
+      "syntax": "<track-list-v0>"
+    },
     "-ms-grid-row-align": {
       "comment": "add this property first since it uses as fallback for flexbox, https://msdn.microsoft.com/en-us/library/windows/apps/hh466348.aspx",
       "syntax": "start | end | center | stretch"
+    },
+    "-ms-grid-rows": {
+      "comment": "misssed old syntax implemented in IE; https://www.w3.org/TR/2012/WD-css3-grid-layout-20120322/#grid-rows",
+      "syntax": "<track-list-v0>"
     },
     "-webkit-appearance": {
       "comment": "webkit specific keywords",
@@ -647,6 +655,18 @@
     "top": {
       "comment": "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",
       "syntax": "<length> | auto"
+    },
+    "track-group": {
+      "comment": "used by old grid-columns and grid-rows syntax v0",
+      "syntax": "[ '(' [ [ <string> ]* <track-minmax> [ <string> ]* ]+ ')' [ '[' <positive-integer> ']' ]? | <track-minmax> ]"
+    },
+    "track-list-v0": {
+      "comment": "used by old grid-columns and grid-rows syntax v0",
+      "syntax": "[ [ <string> ]* <track-group> [ <string> ]* ]+ | 'none'"
+    },
+    "track-minmax": {
+      "comment": "used by old grid-columns and grid-rows syntax v0",
+      "syntax": "'minmax(' <track-breadth> ',' <track-breadth> ')' | 'auto' | <track-breadth> | 'fit-content'"
     },
     "x": {
       "comment": "missed; not sure we should add it, but no others except `cursor` is using it so it's ok for now; https://drafts.csswg.org/css-ui-3/#cursor",

--- a/data/patch.json
+++ b/data/patch.json
@@ -84,6 +84,10 @@
       "comment": "misssed old syntax implemented in IE; https://www.w3.org/TR/2012/WD-css3-grid-layout-20120322/#grid-rows",
       "syntax": "<track-list-v0>"
     },
+    "-ms-hyphenate-limit-last": {
+      "comment": "misssed old syntax implemented in IE; https://www.w3.org/TR/css-text-4/#hyphenate-line-limits",
+      "syntax": "none | always | column | page | spread"
+    },
     "-webkit-appearance": {
       "comment": "webkit specific keywords",
       "references": [

--- a/docs/supported.md
+++ b/docs/supported.md
@@ -64,6 +64,7 @@ Support for a property means CSSTree has a grammar for such property, so its val
 - `-moz-border-right-colors`
 - `-moz-border-top-colors`
 - `-moz-context-properties`
+- `-moz-control-character-visibility`
 - `-moz-float-edge`
 - `-moz-force-broken-image-icon`
 - `-moz-image-region`
@@ -104,9 +105,12 @@ Support for a property means CSSTree has a grammar for such property, so its val
 - `-ms-flow-from`
 - `-ms-flow-into`
 - `-ms-grid-column-align`
+- `-ms-grid-columns`
 - `-ms-grid-row-align`
+- `-ms-grid-rows`
 - `-ms-high-contrast-adjust`
 - `-ms-hyphenate-limit-chars`
+- `-ms-hyphenate-limit-last`
 - `-ms-hyphenate-limit-lines`
 - `-ms-hyphenate-limit-zone`
 - `-ms-ime-align`


### PR DESCRIPTION
Adds new properties from issue list #50
There are 4 new properties:

1. `-moz-control-character-visibility` - I couldn't find any reference to this property in docs and specs. I found only link to bug Mozilla bug tracker where this property was added: https://bugzilla.mozilla.org/show_bug.cgi?id=947588. And w3c emails list with discussions about it: https://lists.w3.org/Archives/Public/www-style/2014Mar/0476.html
2. `-ms-grid-columns` and `-ms-grid-rows` - these two properties are from Grid spec version 0. As I understood they were implemented in IE 10: https://msdn.microsoft.com/en-us/ie/hh772052(v=vs.94). Also I added three new syntaxes: `track-group`, `track-list-v0`, and `track-minmax`. `track-list` exists in mdn/data, but there is a new version of it which isn't compatible we version 0 for `grid-columns` and `grid-rows` properties.
3. `-ms-hyphenate-limit-last` - syntax was taken from spec: https://www.w3.org/TR/css-text-4/#hyphenate-line-limits

Thanks