### PR TITLE
Setup browser field to sync with csso

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "validation"
   ],
   "main": "lib/index.js",
+  "browser": "dist/csstree.min.js",
   "unpkg": "dist/csstree.min.js",
   "jsdelivr": "dist/csstree.min.js",
   "scripts": {


### PR DESCRIPTION
CSSO has specified browser field which affects projects which imports
both css-tree and csso. Better be in sync with csso.

https://github.com/css/csso/blob/master/package.json#L43-L45