### PR TITLE
Migrate tests to es modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -156,9 +162,9 @@
       }
     },
     "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-escapes": {
@@ -191,6 +197,16 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "append-transform": {
@@ -271,6 +287,12 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -279,6 +301,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "browser-stdout": {
@@ -297,16 +328,6 @@
         "make-dir": "^2.0.0",
         "package-hash": "^3.0.0",
         "write-file-atomic": "^2.4.2"
-      }
-    },
-    "call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
       }
     },
     "callsites": {
@@ -343,6 +364,33 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
     },
     "clap": {
       "version": "2.0.1",
@@ -606,15 +654,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -622,9 +661,9 @@
       "dev": true
     },
     "diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
     "doctrine": {
@@ -661,50 +700,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
-      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.2",
-        "is-regex": "^1.1.1",
-        "object-inspect": "^1.8.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.1",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
-      },
-      "dependencies": {
-        "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
-        }
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -715,6 +710,12 @@
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.2.tgz",
       "integrity": "sha512-8d5FCQrR+juXC2u9zjTQ3+IYiuFuaWyKYwmApFJLquTrYNbk36H/+MkRQeTuOJg7IjUchRX2Ulwo1zRYXZ1pUg==",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -915,6 +916,15 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-cache-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -936,13 +946,10 @@
       }
     },
     "flat": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
-      "integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -1006,6 +1013,13 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -1023,17 +1037,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
-      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -1123,12 +1126,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
     "hasha": {
@@ -1303,17 +1300,14 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-      "dev": true
-    },
-    "is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
-      "dev": true
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
     },
     "is-core-module": {
       "version": "2.1.0",
@@ -1323,12 +1317,6 @@
       "requires": {
         "has": "^1.0.3"
       }
-    },
-    "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -1351,20 +1339,17 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-negative-zero": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -1372,19 +1357,16 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
-    "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
-    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
     "isexe": {
@@ -1618,12 +1600,64 @@
       "dev": true
     },
     "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "lru-cache": {
@@ -1714,49 +1748,116 @@
       }
     },
     "mocha": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
-      "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.0.3.tgz",
+      "integrity": "sha512-hnYFrSefHxYS2XFGtN01x8un0EwNu2bzKvhpRFhgoybIvMaOkkL60IVPmkb5h6XDmUl4IMSB+rT5cIO4/4bJgg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "3.2.3",
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "debug": "3.2.6",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
+        "chokidar": "3.5.2",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.7",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "2.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.4",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.5",
-        "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
+        "ms": "2.1.3",
+        "nanoid": "3.1.23",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
         "wide-align": "1.1.3",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "workerpool": "6.1.5",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
           }
         },
         "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1767,45 +1868,124 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "dev": true,
           "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
+            "argparse": "^2.0.1"
           }
         },
-        "mkdirp": {
-          "version": "0.5.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
-          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "p-locate": "^5.0.0"
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "yocto-queue": "^0.1.0"
           }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
         }
       }
     },
@@ -1819,6 +1999,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true
     },
     "natural-compare": {
@@ -1839,24 +2025,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-environment-flags": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
-      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
-      "dev": true,
-      "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -1876,6 +2044,12 @@
           "dev": true
         }
       }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
     },
     "nyc": {
       "version": "14.1.1",
@@ -1915,40 +2089,6 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
-    },
-    "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -2096,6 +2236,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true
+    },
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -2147,6 +2293,15 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -2166,6 +2321,15 @@
       "requires": {
         "find-up": "^3.0.0",
         "read-pkg": "^3.0.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
       }
     },
     "regexpp": {
@@ -2290,6 +2454,15 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -2433,94 +2606,6 @@
         }
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
-      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
-        "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
-        }
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
-      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        },
-        "object.assign": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "has-symbols": "^1.0.1",
-            "object-keys": "^1.1.1"
-          }
-        }
-      }
-    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -2634,6 +2719,15 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",
@@ -2786,6 +2880,12 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
+    "workerpool": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.5.tgz",
+      "integrity": "sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
@@ -2914,15 +3014,36 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
       }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "esbuild": "^0.11.2",
     "eslint": "^6.8.0",
     "json-to-ast": "^2.1.0",
-    "mocha": "^6.2.3",
+    "mdn-data": "2.0.14",
+    "mocha": "^9.0.3",
     "nyc": "^14.1.1"
   },
   "engines": {

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,31 +1,28 @@
-const assert = require('assert');
-const {
-    parse,
-    clone,
-    walk,
-    toPlainObject
-} = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-function createCloneTest(name, getAst) {
-    it(name, () => {
-        const ast = getAst();
-        const astCopy = clone(ast);
-        const astNodes = [];
-        let clonedNodeCount = 0;
-        let nonClonedNodeCount = 0;
+describe('clone()', async () => {
+    const { parse, clone, walk, toPlainObject } = await importLib();
 
-        walk(ast, node => astNodes.push(node));
-        walk(astCopy, node => {
-            clonedNodeCount++;
-            nonClonedNodeCount += astNodes.includes(node);
+    function createCloneTest(name, getAst) {
+        it(name, () => {
+            const ast = getAst();
+            const astCopy = clone(ast);
+            const astNodes = [];
+            let clonedNodeCount = 0;
+            let nonClonedNodeCount = 0;
+
+            walk(ast, node => astNodes.push(node));
+            walk(astCopy, node => {
+                clonedNodeCount++;
+                nonClonedNodeCount += astNodes.includes(node);
+            });
+
+            assert.strictEqual(clonedNodeCount, astNodes.length);
+            assert.strictEqual(nonClonedNodeCount, 0);
         });
+    }
 
-        assert.strictEqual(clonedNodeCount, astNodes.length);
-        assert.strictEqual(nonClonedNodeCount, 0);
-    });
-}
-
-describe('clone()', function() {
     createCloneTest('a regular AST', () =>
         parse('.test{color:red;}@media foo{div{color:green}}')
     );

--- a/test/common.js
+++ b/test/common.js
@@ -1,17 +1,26 @@
-const fs = require('fs');
-const path = require('path');
-const assert = require('assert');
-const { parse, walk, fork, version } = require('./helpers/lib');
+import fs from 'fs';
+import url from 'url';
+import path from 'path';
+import assert from 'assert';
+import { createRequire } from 'module';
+import importLib from './helpers/lib.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
 const fixtureFilename = '/fixture/stringify.css';
 const fixture = normalize(fs.readFileSync(__dirname + fixtureFilename, 'utf-8'));;
-const types = Object.keys(parse.config.node).sort()
-    .filter(type => type !== 'DeclarationList'); // DeclarationList doesn't appear in StyleSheet
 
 function normalize(str) {
     return str.replace(/\n|\r\n?|\f/g, '\n');
 }
 
-describe('Common', () => {
+describe('Common', async () => {
+    const { parse, walk, fork, version } = await importLib();
+
+    const types = Object.keys(parse.config.node).sort()
+        .filter(type => type !== 'DeclarationList'); // DeclarationList doesn't appear in StyleSheet
+
     it('should expose version', () => {
         assert.strictEqual(version, require('../package.json').version);
     });

--- a/test/convert.js
+++ b/test/convert.js
@@ -1,8 +1,11 @@
-const assert = require('assert');
-const { parse, generate, fromPlainObject, toPlainObject } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+
 const css = '.test{a:123}';
 
-describe('convert', () => {
+describe('convert', async () => {
+    const { parse, generate, fromPlainObject, toPlainObject } = await importLib();
+
     it('fromPlainObject', () => {
         const ast = parse(css);
         const plainObject = JSON.parse(JSON.stringify(ast));

--- a/test/decode-encode.js
+++ b/test/decode-encode.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const { ident, string, url } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
 function forEachTest(tests, func) {
     Object.keys(tests).forEach((from, idx) => {
@@ -9,7 +9,9 @@ function forEachTest(tests, func) {
     });
 }
 
-describe('decode/encode', () => {
+describe('decode/encode', async () => {
+    const { ident, string, url } = await importLib();
+
     describe('string', () => {
         describe('decode', () => {
             const tests = {

--- a/test/definition-syntax-generate.js
+++ b/test/definition-syntax-generate.js
@@ -1,16 +1,20 @@
-const assert = require('assert');
-const { lexer, definitionSyntax: { parse, generate } } = require('./helpers/lib');
-const assertGenerateParseRoundTrip = (syntax) => assert.deepStrictEqual(parse(generate(syntax)), syntax);
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-function createParseGenerateTest(test) {
-    it(test.source + (test.generate ? ' → ' + test.generate : ''), () => {
-        const actual = generate(parse(test.source));
+describe('definitionSyntax.generate()', async () => {
+    const { lexer, definitionSyntax: { parse, generate } } = await importLib();
 
-        assert.strictEqual(actual, test.generate || test.source);
-    });
-}
+    const assertGenerateParseRoundTrip = (syntax) => assert.deepStrictEqual(parse(generate(syntax)), syntax);
 
-describe('definitionSyntax.generate()', () => {
+    function createParseGenerateTest(test) {
+        it(test.source + (test.generate ? ' → ' + test.generate : ''), () => {
+            const actual = generate(parse(test.source));
+
+            assert.strictEqual(actual, test.generate || test.source);
+        });
+    }
+
+
     it('should throw an exception on bad node type', () =>
         assert.throws(
             () => generate({ type: 'Unknown' }),

--- a/test/definition-syntax-match.js
+++ b/test/definition-syntax-match.js
@@ -1,9 +1,9 @@
-const assert = require('assert');
-const prepareTokens = require('../lib/lexer/prepare-tokens');
-const genericSyntaxes = require('../lib/lexer/generic');
-const { buildMatchGraph } = require('../lib/lexer/match-graph');
-const { matchAsList, matchAsTree } = require('../lib/lexer/match');
-const fixture = require('./fixture/definition-syntax-match');
+import assert from 'assert';
+import prepareTokens from '../lib/lexer/prepare-tokens.js';
+import genericSyntaxes from '../lib/lexer/generic.js';
+import { buildMatchGraph } from '../lib/lexer/match-graph.js';
+import { matchAsList, matchAsTree } from '../lib/lexer/match.js';
+import * as fixture from './fixture/definition-syntax-match/index.js';
 
 function processMatchResult(mr) {
     if (Array.isArray(mr)) {

--- a/test/definition-syntax-parse.js
+++ b/test/definition-syntax-parse.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { lexer, definitionSyntax: { parse } } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('definitionSyntax.parse()', () => {
+describe('definitionSyntax.parse()', async () => {
+    const { lexer, definitionSyntax: { parse } } = await importLib();
+
     describe('combinator precedence', () => {
         const combinators = [' ', '&&', '||', '|']; // higher goes first
         const print = node => {

--- a/test/definition-syntax-walk.js
+++ b/test/definition-syntax-walk.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { definitionSyntax: { parse, generate, walk } } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('definitionSyntax.walk()', () => {
+describe('definitionSyntax.walk()', async () => {
+    const { definitionSyntax: { parse, generate, walk } } = await importLib();
+
     it('pass a single walk function', () => {
         const ast = parse('a b | c() && [ <d>? || <\'e\'> || ( f{2,4} ) ]*');
         const visited = [];

--- a/test/find.js
+++ b/test/find.js
@@ -1,24 +1,27 @@
-const assert = require('assert');
-const { parse, find, findLast, findAll } = require('./helpers/lib');
-const { lazyValues } = require('./helpers');
-const values = lazyValues({
-    ast: () => parse(`
-        .foo { color: red; background: green; }
-        .bar, .qux.foo { font-weight: bold; color: blue; }
-    `),
-    firstFoo: () => values.ast
-        .children.first    // Rule
-        .prelude           // SelectorList
-        .children.first    // Selector
-        .children.first,   // ClassSelector
-    lastFoo: () => values.ast
-        .children.last     // Rule
-        .prelude           // SelectorList
-        .children.last     // Selector
-        .children.last     // ClassSelector
-});
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+import { lazyValues } from './helpers/index.js';
 
-describe('Search', () => {
+describe('Search', async () => {
+    const { parse, find, findLast, findAll } = await importLib();
+
+    const values = lazyValues({
+        ast: () => parse(`
+            .foo { color: red; background: green; }
+            .bar, .qux.foo { font-weight: bold; color: blue; }
+        `),
+        firstFoo: () => values.ast
+            .children.first    // Rule
+            .prelude           // SelectorList
+            .children.first    // Selector
+            .children.first,   // ClassSelector
+        lastFoo: () => values.ast
+            .children.last     // Rule
+            .prelude           // SelectorList
+            .children.last     // Selector
+            .children.last     // ClassSelector
+    });
+
     describe('find', () => {
         it('base', () => {
             const actual = find(values.ast, node =>

--- a/test/fixture/ast/index.js
+++ b/test/fixture/ast/index.js
@@ -1,6 +1,12 @@
-const fs = require('fs');
-const path = require('path');
-const JsonLocator = require('../../helpers/JsonLocator.js');
+import fs from 'fs';
+import url from 'url';
+import path from 'path';
+import { createRequire } from 'module';
+import JsonLocator from '../../helpers/JsonLocator.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
 const wrapper = {
     stylesheet: ast => ({
         type: 'StyleSheet',
@@ -28,7 +34,7 @@ const wrapper = {
     })
 };
 
-function forEachTest(factory, errors) {
+export function forEachTest(factory, errors) {
     const testType = errors === true ? 'errors' : 'tests';
     for (const filename in tests) {
         const file = tests[filename];
@@ -39,7 +45,7 @@ function forEachTest(factory, errors) {
     };
 }
 
-const tests = fs.readdirSync(__dirname).reduce((result, scope) => {
+export const tests = fs.readdirSync(__dirname).reduce((result, scope) => {
     function scanDir(dir) {
         if (fs.statSync(dir).isDirectory()) {
             fs.readdirSync(dir).forEach(fn => {
@@ -119,8 +125,3 @@ const tests = fs.readdirSync(__dirname).reduce((result, scope) => {
 
     return result;
 }, {});
-
-module.exports = {
-    forEachTest,
-    tests
-};

--- a/test/fixture/definition-syntax-match/index.js
+++ b/test/fixture/definition-syntax-match/index.js
@@ -1,8 +1,13 @@
-const fs = require('fs');
-const path = require('path');
-const JsonLocator = require('../../helpers/JsonLocator.js');
+import fs from 'fs';
+import url from 'url';
+import path from 'path';
+import { createRequire } from 'module';
+import JsonLocator from '../../helpers/JsonLocator.js';
 
-function forEachTest(factory) {
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+export function forEachTest(factory) {
     for (const filename in tests) {
         const file = tests[filename];
 
@@ -12,7 +17,7 @@ function forEachTest(factory) {
     };
 }
 
-const tests = fs.readdirSync(__dirname).reduce((result, fn) => {
+export const tests = fs.readdirSync(__dirname).reduce((result, fn) => {
     if (fn !== 'index.js') {
         const filename = path.join(__dirname, fn);
         const tests = require(filename);
@@ -27,8 +32,3 @@ const tests = fs.readdirSync(__dirname).reduce((result, fn) => {
 
     return result;
 }, {});
-
-module.exports = {
-    forEachTest,
-    tests
-};

--- a/test/fixture/definition-syntax/index.js
+++ b/test/fixture/definition-syntax/index.js
@@ -1,10 +1,15 @@
-const fs = require('fs');
-const path = require('path');
-const createLexer = require('../../../lib').createLexer;
-const defaultLexer = require('../../../lib').lexer;
-const JsonLocator = require('../../helpers/JsonLocator.js');
+import fs from 'fs';
+import url from 'url';
+import path from 'path';
+import { createRequire } from 'module';
+import csstree from '../../../lib/index.js';
+import JsonLocator from '../../helpers/JsonLocator.js';
 
-function forEachTest(factory) {
+const require = createRequire(import.meta.url);
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const { createLexer, lexer: defaultLexer } = csstree;
+
+export function forEachTest(factory) {
     for (const filename in tests) {
         const file = tests[filename];
 
@@ -34,7 +39,7 @@ function forEachTest(factory) {
     }
 }
 
-function forEachAtrulePreludeTest(factory) {
+export function forEachAtrulePreludeTest(factory) {
     for (const atruleName in atruleTests) {
         const testset = atruleTests[atruleName];
 
@@ -60,7 +65,7 @@ function forEachAtrulePreludeTest(factory) {
     }
 }
 
-function forEachAtruleDescriptorTest(factory) {
+export function forEachAtruleDescriptorTest(factory) {
     for (const atruleName in atruleTests) {
         const testset = atruleTests[atruleName];
 
@@ -89,7 +94,7 @@ function forEachAtruleDescriptorTest(factory) {
     }
 }
 
-const tests = fs.readdirSync(__dirname).reduce(function(result, fn) {
+export const tests = fs.readdirSync(__dirname).reduce(function(result, fn) {
     if (fn !== 'index.js' && fn !== 'atrules.json') {
         const filename = path.join(__dirname, fn);
         const tests = require(filename);
@@ -105,7 +110,7 @@ const tests = fs.readdirSync(__dirname).reduce(function(result, fn) {
     return result;
 }, {});
 
-const atruleTests = (() => {
+export const atruleTests = (() => {
     const filename = path.join(__dirname, 'atrules.json');
     const tests = require(filename);
     const locator = new JsonLocator(filename);
@@ -116,11 +121,3 @@ const atruleTests = (() => {
 
     return tests;
 })();
-
-module.exports = {
-    forEachTest,
-    forEachAtrulePreludeTest,
-    forEachAtruleDescriptorTest,
-    tests,
-    atruleTests
-};

--- a/test/fixture/tokenize/index.js
+++ b/test/fixture/tokenize/index.js
@@ -1,6 +1,11 @@
-const fs = require('fs');
-const path = require('path');
-const JsonLocator = require('../../helpers/JsonLocator.js');
+import fs from 'fs';
+import url from 'url';
+import path from 'path';
+import { createRequire } from 'module';
+import JsonLocator from '../../helpers/JsonLocator.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
 
 function ensureArray(value) {
     return Array.isArray(value) ? value : [];
@@ -24,7 +29,7 @@ function processTests(tests, key, type, locator) {
     });
 }
 
-function forEachTest(testType, factory) {
+export function forEachTest(testType, factory) {
     for (const filename in tests) {
         const file = tests[filename];
 
@@ -37,7 +42,7 @@ function forEachTest(testType, factory) {
     };
 }
 
-const tests = fs.readdirSync(__dirname).reduce(function(result, filename) {
+export const tests = fs.readdirSync(__dirname).reduce(function(result, filename) {
     const absFilename = path.join(__dirname, filename);
 
     if (path.extname(filename) !== '.json' || fs.statSync(absFilename).isDirectory()) {
@@ -59,8 +64,3 @@ const tests = fs.readdirSync(__dirname).reduce(function(result, filename) {
 
     return result;
 }, {});
-
-module.exports = {
-    forEachTest,
-    tests
-};

--- a/test/generate.js
+++ b/test/generate.js
@@ -1,57 +1,59 @@
-const assert = require('assert');
-const { parse, generate, toPlainObject } = require('./helpers/lib');
-const forEachAstTest = require('./fixture/ast').forEachTest;
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+import { forEachTest as forEachAstTest } from './fixture/ast/index.js';
 
-function createGenerateTests(name, test) {
-    (test.skip ? it.skip : it)(name, () => {
-        const ast = parse(test.source, test.options);
-        const actual = generate(ast);
-        const expected = 'generate' in test ? test.generate : test.source;
+describe('generate', async () => {
+    const { parse, generate, toPlainObject } = await importLib();
 
-        // strings should be equal
-        assert.strictEqual(actual, expected);
-    });
+    function createGenerateTests(name, test) {
+        (test.skip ? it.skip : it)(name, () => {
+            const ast = parse(test.source, test.options);
+            const actual = generate(ast);
+            const expected = 'generate' in test ? test.generate : test.source;
 
-    (test.skip ? it.skip : it)(name + ' (plain object)', () => {
-        const ast = parse(test.source, test.options);
-        const actual = generate(toPlainObject(ast));
-        const expected = 'generate' in test ? test.generate : test.source;
-
-        // strings should be equal
-        assert.strictEqual(actual, expected);
-    });
-
-    // FIXME: Skip some test cases for round-trip check until generator's improvements
-    const skipRoundTrip = test.skip || /block at-rule #c\.2|atruler\.c\.2|parentheses\.c\.3/.test(name);
-    (skipRoundTrip ? it.skip : it)(name + ' (round-trip)', () => {
-        const expected = parse(test.source, test.options);
-        const actual = parse(generate(expected), test.options);
-
-        // https://drafts.csswg.org/css-syntax/#serialization
-        // The only requirement for serialization is that it must "round-trip" with parsing,
-        // that is, parsing the stylesheet must produce the same data structures as parsing,
-        // serializing, and parsing again, except for consecutive <whitespace-token>s,
-        // which may be collapsed into a single token.
-        assert.deepStrictEqual(actual, expected);
-    });
-}
-
-function createGenerateWithSourceMapTest(name, test) {
-    (test.skip ? it.skip : it)(name, () => {
-        const ast = parse(test.source, {
-            ...test.options,
-            positions: true
+            // strings should be equal
+            assert.strictEqual(actual, expected);
         });
 
-        // strings should be equal
-        assert.strictEqual(
-            generate(ast, { sourceMap: true }).css,
-            'generate' in test ? test.generate : test.source
-        );
-    });
-}
+        (test.skip ? it.skip : it)(name + ' (plain object)', () => {
+            const ast = parse(test.source, test.options);
+            const actual = generate(toPlainObject(ast));
+            const expected = 'generate' in test ? test.generate : test.source;
 
-describe('generate', () => {
+            // strings should be equal
+            assert.strictEqual(actual, expected);
+        });
+
+        // FIXME: Skip some test cases for round-trip check until generator's improvements
+        const skipRoundTrip = test.skip || /block at-rule #c\.2|atruler\.c\.2|parentheses\.c\.3/.test(name);
+        (skipRoundTrip ? it.skip : it)(name + ' (round-trip)', () => {
+            const expected = parse(test.source, test.options);
+            const actual = parse(generate(expected), test.options);
+
+            // https://drafts.csswg.org/css-syntax/#serialization
+            // The only requirement for serialization is that it must "round-trip" with parsing,
+            // that is, parsing the stylesheet must produce the same data structures as parsing,
+            // serializing, and parsing again, except for consecutive <whitespace-token>s,
+            // which may be collapsed into a single token.
+            assert.deepStrictEqual(actual, expected);
+        });
+    }
+
+    function createGenerateWithSourceMapTest(name, test) {
+        (test.skip ? it.skip : it)(name, () => {
+            const ast = parse(test.source, {
+                ...test.options,
+                positions: true
+            });
+
+            // strings should be equal
+            assert.strictEqual(
+                generate(ast, { sourceMap: true }).css,
+                'generate' in test ? test.generate : test.source
+            );
+        });
+    }
+
     forEachAstTest(createGenerateTests);
 
     it('should throws on unknown node type', () =>

--- a/test/helpers/JsonLocator.js
+++ b/test/helpers/JsonLocator.js
@@ -1,8 +1,11 @@
-const fs = require('fs');
-const path = require('path');
-const parseJSON = require('json-to-ast');
+import fs from 'fs';
+import url from 'url';
+import path from 'path';
+import parseJSON from 'json-to-ast';
 
-module.exports = class JsonLocator {
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+export default class JsonLocator {
     constructor(filename) {
         let ast = null;
 

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,4 +1,4 @@
-function lazyValues(dict) {
+export function lazyValues(dict) {
     const result = Object.create(null);
 
     for (const [key, compute] of Object.entries(dict)) {
@@ -13,8 +13,4 @@ function lazyValues(dict) {
     }
 
     return result;
-};
-
-module.exports = {
-    lazyValues
 };

--- a/test/helpers/lib.js
+++ b/test/helpers/lib.js
@@ -1,4 +1,5 @@
-const chalk = require('chalk');
+import chalk from 'chalk';
+
 const libPaths = {
     'src': 'lib/index.js',
     'dist': 'dist/csstree.js',
@@ -15,4 +16,7 @@ if (!libPaths.hasOwnProperty(mode)) {
 
 console.info('Test lib entry:', chalk.yellow(libPath + postfix));
 
-module.exports = require('../../' + libPath);
+export default async function importLib() {
+  const { default: lib } = await import('../../' + libPath);
+  return lib;
+}

--- a/test/lexer-check-atrule-descriptor.js
+++ b/test/lexer-check-atrule-descriptor.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { lexer } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('Lexer#checkAtruleDescriptorName()', () => {
+describe('Lexer#checkAtruleDescriptorName()', async () => {
+    const { lexer } = await importLib();
+
     it('should fail on invalid atrule', () => {
         const error = lexer.checkAtruleDescriptorName('foo');
         assert.strictEqual(error.name, 'SyntaxReferenceError');

--- a/test/lexer-check-atrule-name.js
+++ b/test/lexer-check-atrule-name.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { lexer } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('Lexer#checkAtruleName()', () => {
+describe('Lexer#checkAtruleName()', async () => {
+    const { lexer } = await importLib();
+
     it('should pass correct atrule', () => {
         assert.strictEqual(lexer.checkAtruleName('media'), undefined);
     });

--- a/test/lexer-check-atrule-prelude.js
+++ b/test/lexer-check-atrule-prelude.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { lexer } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('Lexer#checkAtrulePrelude()', () => {
+describe('Lexer#checkAtrulePrelude()', async () => {
+    const { lexer } = await importLib();
+
     it('should fail on invalid atrule', () => {
         const error = lexer.checkAtrulePrelude('foo');
         assert.strictEqual(error.name, 'SyntaxReferenceError');

--- a/test/lexer-check-property-name.js
+++ b/test/lexer-check-property-name.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { lexer } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('Lexer#checkPropertyName()', () => {
+describe('Lexer#checkPropertyName()', async () => {
+    const { lexer } = await importLib();
+
     it('should pass correct property', () => {
         assert.strictEqual(lexer.checkPropertyName('color'), undefined);
     });

--- a/test/lexer-check-structure.js
+++ b/test/lexer-check-structure.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const { parse, lexer, fork } = require('./helpers/lib');
-const forEachAstTest = require('./fixture/ast').forEachTest;
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+import { forEachTest as forEachAstTest } from './fixture/ast/index.js';
 
-describe('Lexer#checkStructure()', () => {
+describe('Lexer#checkStructure()', async () => {
+    const { parse, lexer, fork } = await importLib();
+
     describe('structure in AST node definition', () => {
         it('should fail when no structure field in node definition', () => {
             assert.throws(

--- a/test/lexer-match-atrule-descriptor.js
+++ b/test/lexer-match-atrule-descriptor.js
@@ -1,26 +1,29 @@
-const assert = require('assert');
-const { parse, lexer, fork } = require('./helpers/lib');
-const { lazyValues } = require('./helpers');
-const fixture = require('./fixture/definition-syntax');
-const values = lazyValues({
-    swapValue: () => parse('swap', { context: 'value' }),
-    xxxValue: () => parse('xxx', { context: 'value' }),
-    inherit: () => parse('inherit', { context: 'value' }),
-    fontDisplaySyntax: () => 'auto | block | swap | fallback | optional',
-    customSyntax: () => fork(prev => ({
-        ...prev,
-        atrules: {
-            'font-face': {
-                descriptors: {
-                    'font-display': values.fontDisplaySyntax,
-                    '-foo-font-display': `${values.fontDisplaySyntax} | xxx`
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+import { lazyValues } from './helpers/index.js';
+import * as fixture from './fixture/definition-syntax/index.js';
+
+describe('Lexer#matchAtruleDescriptor()', async () => {
+    const { parse, lexer, fork } = await importLib();
+
+    const values = lazyValues({
+        swapValue: () => parse('swap', { context: 'value' }),
+        xxxValue: () => parse('xxx', { context: 'value' }),
+        inherit: () => parse('inherit', { context: 'value' }),
+        fontDisplaySyntax: () => 'auto | block | swap | fallback | optional',
+        customSyntax: () => fork(prev => ({
+            ...prev,
+            atrules: {
+                'font-face': {
+                    descriptors: {
+                        'font-display': values.fontDisplaySyntax,
+                        '-foo-font-display': `${values.fontDisplaySyntax} | xxx`
+                    }
                 }
             }
-        }
-    }))
-});
+        }))
+    });
 
-describe('Lexer#matchAtruleDescriptor()', () => {
     it('should match', () => {
         const match = values.customSyntax.lexer.matchAtruleDescriptor('font-face', 'font-display', values.swapValue);
 

--- a/test/lexer-match-atrule-prelude.js
+++ b/test/lexer-match-atrule-prelude.js
@@ -1,20 +1,23 @@
-const assert = require('assert');
-const { parse, lexer, fork } = require('./helpers/lib');
-const { lazyValues } = require('./helpers');
-const fixture = require('./fixture/definition-syntax');
-const values = lazyValues({
-    animationName: () => parse('animation-name', { context: 'atrulePrelude', atrule: 'keyframes' }),
-    number: () => parse('123', { context: 'atrulePrelude', atrule: 'unknown' }),
-    customSyntax: () => fork({
-        atrules: {
-            '-foo-keyframes': {
-                prelude: '<number>'
-            }
-        }
-    })
-});
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+import { lazyValues } from './helpers/index.js';
+import * as fixture from './fixture/definition-syntax/index.js';
 
-describe('Lexer#matchAtrulePrelude()', () => {
+describe('Lexer#matchAtrulePrelude()', async () => {
+    const { parse, lexer, fork } = await importLib();
+
+    const values = lazyValues({
+        animationName: () => parse('animation-name', { context: 'atrulePrelude', atrule: 'keyframes' }),
+        number: () => parse('123', { context: 'atrulePrelude', atrule: 'unknown' }),
+        customSyntax: () => fork({
+            atrules: {
+                '-foo-keyframes': {
+                    prelude: '<number>'
+                }
+            }
+        })
+    });
+
     it('should match', () => {
         const match = values.customSyntax.lexer.matchAtrulePrelude('keyframes', values.animationName);
 

--- a/test/lexer-match-property.js
+++ b/test/lexer-match-property.js
@@ -1,20 +1,7 @@
-const assert = require('assert');
-const { parse, lexer, fork } = require('./helpers/lib');
-const { lazyValues } = require('./helpers');
-const fixture = require('./fixture/definition-syntax');
-const values = lazyValues({
-    bar: () => parse('bar', { context: 'value' }),
-    qux: () => parse('qux', { context: 'value' }),
-    inherit: () => parse('inherit', { context: 'value' }),
-    customSyntax: () => fork(function(prev, assign) {
-        return assign(prev, {
-            properties: {
-                foo: 'bar',
-                '-baz-foo': 'qux'
-            }
-        });
-    })
-});
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+import { lazyValues } from './helpers/index.js';
+import * as fixture from './fixture/definition-syntax/index.js';
 
 function getMatch(lexer, property, value, syntax) {
     return syntax
@@ -22,7 +9,23 @@ function getMatch(lexer, property, value, syntax) {
         : lexer.matchProperty(property, value);
 }
 
-describe('Lexer#matchProperty()', () => {
+describe('Lexer#matchProperty()', async () => {
+    const { parse, lexer, fork } = await importLib();
+
+    const values = lazyValues({
+        bar: () => parse('bar', { context: 'value' }),
+        qux: () => parse('qux', { context: 'value' }),
+        inherit: () => parse('inherit', { context: 'value' }),
+        customSyntax: () => fork(function(prev, assign) {
+            return assign(prev, {
+                properties: {
+                    foo: 'bar',
+                    '-baz-foo': 'qux'
+                }
+            });
+        })
+    });
+
     describe('vendor prefixes and hacks', () => {
         it('vendor prefix', () => {
             const match = values.customSyntax.lexer.matchProperty('-vendor-foo', values.bar);

--- a/test/lexer-match-result.js
+++ b/test/lexer-match-result.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { parse, lexer } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('lexer match result', () => {
+describe('lexer match result', async () => {
+    const { parse, lexer } = await importLib();
+
     let testNode;
     let match;
     let mismatch;

--- a/test/lexer-match-type.js
+++ b/test/lexer-match-type.js
@@ -1,20 +1,23 @@
-const assert = require('assert');
-const { lazyValues } = require('./helpers');
-const { parse, fork } = require('./helpers/lib');
-const values = lazyValues({
-    singleNumber: () => parse('1', { context: 'value' }),
-    severalNumbers: () => parse('1, 2, 3', { context: 'value' }),
-    cssWideKeyword: () => parse('inherit', { context: 'value' }),
-    customSyntax: () => fork(prev => ({
-        ...prev,
-        types: {
-            foo: '<bar>#',
-            bar: '[ 1 | 2 | 3 ]'
-        }
-    }))
-});
+import assert from 'assert';
+import { lazyValues } from './helpers/index.js';
+import importLib from './helpers/lib.js';
 
-describe('Lexer#matchType()', () => {
+describe('Lexer#matchType()', async () => {
+    const { parse, fork } = await importLib();
+
+    const values = lazyValues({
+        singleNumber: () => parse('1', { context: 'value' }),
+        severalNumbers: () => parse('1, 2, 3', { context: 'value' }),
+        cssWideKeyword: () => parse('inherit', { context: 'value' }),
+        customSyntax: () => fork(prev => ({
+            ...prev,
+            types: {
+                foo: '<bar>#',
+                bar: '[ 1 | 2 | 3 ]'
+            }
+        }))
+    });
+
     it('should match type', () => {
         const match = values.customSyntax.lexer.matchType('bar', values.singleNumber);
 

--- a/test/lexer-match.js
+++ b/test/lexer-match.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { parse, generate, fork } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('Lexer#match()', () => {
+describe('Lexer#match()', async () => {
+    const { parse, generate, fork } = await importLib();
+
     const customSyntax = fork(prev => ({
         ...prev,
         types: {

--- a/test/lexer-search-fragments.js
+++ b/test/lexer-search-fragments.js
@@ -1,15 +1,17 @@
-const assert = require('assert');
-const { parse, generate, lexer } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-function translateFragments(fragments) {
-    return fragments.map(fragment => generate({
-        type: 'Value',
-        loc: null,
-        children: fragment.nodes
-    }));
-}
+describe('lexer search fragments', async () => {
+    const { parse, generate, lexer } = await importLib();
 
-describe('lexer search fragments', () => {
+    function translateFragments(fragments) {
+        return fragments.map(fragment => generate({
+            type: 'Value',
+            loc: null,
+            children: fragment.nodes
+        }));
+    }
+
     describe('findValueFragments()', () => {
         it('should find single entry', () => {
             const declaration = parse('border: 1px solid red', { context: 'declaration' });

--- a/test/lexer.js
+++ b/test/lexer.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { lexer, createLexer, fork } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('lexer', () => {
+describe('lexer', async () => {
+    const { lexer, createLexer, fork } = await importLib();
+
     it('should not override generic types when used', () => {
         const customLexer = createLexer({
             generic: true,

--- a/test/list.js
+++ b/test/list.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-const { List } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
 function getFirstArg(data) {
     return data;
@@ -99,7 +99,7 @@ function createIteratorTests(list, method, items, until, retValue) {
     });
 }
 
-function createIteratorWithModificationTests(list, method, items, until, retValue) {
+function createIteratorWithModificationTests(List, list, method, items, until, retValue) {
     const iterate = until !== undefined
         ? function(list, ...args) {
             let untilCopy = null;
@@ -176,7 +176,9 @@ function createIteratorWithModificationTests(list, method, items, until, retValu
     });
 }
 
-describe('List', () => {
+describe('List', async () => {
+    const { List } = await importLib();
+
     const foo = {};
     const bar = {};
     let empty;
@@ -251,13 +253,13 @@ describe('List', () => {
     describe('#forEach()', () => {
         const iterateList = new List().fromArray([foo, bar]);
         createIteratorTests(iterateList, 'forEach', [iterateList.head, iterateList.tail]);
-        createIteratorWithModificationTests(iterateList, 'forEach', [iterateList.head, iterateList.tail]);
+        createIteratorWithModificationTests(List, iterateList, 'forEach', [iterateList.head, iterateList.tail]);
     });
 
     describe('#forEachRight()', () => {
         const iterateList = new List().fromArray([foo, bar]);
         createIteratorTests(iterateList, 'forEachRight', [iterateList.tail, iterateList.head]);
-        createIteratorWithModificationTests(iterateList, 'forEachRight', [iterateList.tail, iterateList.head]);
+        createIteratorWithModificationTests(List, iterateList, 'forEachRight', [iterateList.tail, iterateList.head]);
     });
 
     it('#reduce()', function() {
@@ -298,7 +300,7 @@ describe('List', () => {
 
         const iterateList = new List().fromArray([foo, bar]);
         createIteratorTests(iterateList, 'nextUntil', [iterateList.head, iterateList.tail], iterateList.head);
-        createIteratorWithModificationTests(iterateList, 'nextUntil', [iterateList.head, iterateList.tail], iterateList.head);
+        createIteratorWithModificationTests(List, iterateList, 'nextUntil', [iterateList.head, iterateList.tail], iterateList.head);
     });
 
     describe('#prevUntil()', () => {
@@ -325,7 +327,7 @@ describe('List', () => {
 
         const iterateList = new List().fromArray([foo, bar]);
         createIteratorTests(iterateList, 'prevUntil', [iterateList.tail, iterateList.head], iterateList.tail);
-        createIteratorWithModificationTests(iterateList, 'prevUntil', [iterateList.tail, iterateList.head], iterateList.tail);
+        createIteratorWithModificationTests(List, iterateList, 'prevUntil', [iterateList.tail, iterateList.head], iterateList.tail);
     });
 
     describe('#some()', () => {

--- a/test/names.js
+++ b/test/names.js
@@ -1,7 +1,9 @@
-const assert = require('assert');
-const { keyword, property, isCustomProperty, vendorPrefix } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
-describe('names utils', () => {
+describe('names utils', async () => {
+    const { keyword, property, isCustomProperty, vendorPrefix } = await importLib();
+
     describe('keyword', () => {
         it('base test', () => {
             assert.deepStrictEqual(keyword('test'), {
@@ -15,13 +17,10 @@ describe('names utils', () => {
 
         it('result should be immutable', () => {
             const data = keyword('test');
-            data.name = 'xxx';
-            assert.deepStrictEqual(data, {
-                name: 'test',
-                basename: 'test',
-                prefix: '',
-                vendor: '',
-                custom: false
+            assert.throws(() => {
+              data.name = 'xxx';
+            }, {
+              message: /Cannot assign to read only property 'name' of object/
             });
         });
 
@@ -101,14 +100,10 @@ describe('names utils', () => {
 
         it('result should be immutable', () => {
             const data = property('test');
-            data.name = 'xxx';
-            assert.deepStrictEqual(data, {
-                name: 'test',
-                basename: 'test',
-                custom: false,
-                prefix: '',
-                hack: '',
-                vendor: ''
+            assert.throws(() => {
+                data.name = 'xxx';
+            }, {
+              message: /Cannot assign to read only property 'name' of object/
             });
         });
 

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/parse-extension.js
+++ b/test/parse-extension.js
@@ -1,10 +1,12 @@
-const assert = require('assert');
-const { parse, tokenize: { TYPE }, toPlainObject, fork } = require('./helpers/lib');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
 
 const DollarSign = 0x0024; // U+0024 DOLLAR SIGN ($)
 const Ampersand = 0x0026;  // U+0026 ANPERSAND (&)
 
-describe('extension', () => {
+describe('extension', async () => {
+    const { parse, tokenize: { TYPE }, toPlainObject, fork } = await importLib();
+
     describe('value', () => {
         const extended = fork(syntaxConfig => {
             const defaultGetNode = syntaxConfig.scope.Value.getNode;

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,34 +1,40 @@
-const assert = require('assert');
-const { parse, walk, List } = require('./helpers/lib');
-const forEachAstTest = require('./fixture/ast').forEachTest;
+import assert from 'assert';
+import { createRequire } from 'module';
+import importLib from './helpers/lib.js';
+import { forEachTest as forEachAstTest } from './fixture/ast/index.js';
+
+const require = createRequire(import.meta.url);
 const genericTypesFixture = require('./fixture/definition-syntax-match/generic.json');
+
 const stringifyWithNoLoc = ast => JSON.stringify(ast, (key, value) => key !== 'loc' ? value : undefined, 4);
 
-function createParseErrorTest(name, test, options) {
-    (test.skip ? it.skip : it)(`${name} ${JSON.stringify(test.source)}`, () => {
-        let error;
+describe('parse', async () => {
+    const { parse, walk, List } = await importLib();
 
-        assert.throws(
-            () => parse(test.source, options),
-            (e) => {
-                error = e;
-                if (e instanceof parse.SyntaxError === false) {
-                    return true;
-                }
-            },
-            'Should be a CSS parse error'
-        );
+    function createParseErrorTest(name, test, options) {
+        (test.skip ? it.skip : it)(`${name} ${JSON.stringify(test.source)}`, () => {
+            let error;
 
-        assert.strictEqual(error.message, test.error);
-        assert.deepStrictEqual({
-            offset: error.offset,
-            line: error.line,
-            column: error.column
-        }, test.position);
-    });
-}
+            assert.throws(
+                () => parse(test.source, options),
+                (e) => {
+                    error = e;
+                    if (e instanceof parse.SyntaxError === false) {
+                        return true;
+                    }
+                },
+                'Should be a CSS parse error'
+            );
 
-describe('parse', () => {
+            assert.strictEqual(error.message, test.error);
+            assert.deepStrictEqual({
+                offset: error.offset,
+                line: error.line,
+                column: error.column
+            }, test.position);
+        });
+    }
+
     describe('basic', () => {
         forEachAstTest((name, test) => {
             (test.skip ? it.skip : it)(name, () => {

--- a/test/standalone.js
+++ b/test/standalone.js
@@ -1,9 +1,10 @@
-const assert = require('assert');
-const List = require('../lib/common/List');
-const parse = require('../lib/parser');
-const walk = require('../lib/walker');
-const generate = require('../lib/generator');
-const convertor = require('../lib/convertor');
+import assert from 'assert';
+import List from '../lib/common/List.js';
+import parse from '../lib/parser/index.js';
+import walk from '../lib/walker/index.js';
+import generate from '../lib/generator/index.js';
+import convertor from '../lib/convertor/index.js';
+
 const stringifyWithNoInfo = ast => JSON.stringify(ast, (key, value) => key !== 'loc' ? value : undefined, 4);
 
 const css = '.a{}';

--- a/test/tokenizer.js
+++ b/test/tokenizer.js
@@ -1,8 +1,10 @@
-const assert = require('assert');
-const { TokenStream, tokenize } = require('./helpers/lib');
-const fixture = require('./fixture/tokenize');
+import assert from 'assert';
+import importLib from './helpers/lib.js';
+import * as fixture from './fixture/tokenize/index.js';
 
-describe('tokenize/stream', () => {
+describe('tokenize/stream', async () => {
+    const { TokenStream, tokenize } = await importLib();
+
     const createStream = source => new TokenStream(source, tokenize);
     const css = '.test\n{\n  prop: url(foo/bar.jpg) url( a\\(\\33 \\).\\ \\"\\\'test ) calc(1 + 1) \\x \\aa ;\n}<!--<-->\\\n';
     const tokens = [


### PR DESCRIPTION
Enabled native es modules only for tests via nested package.json.
Testing different versions is solved with dynamic import inside async
describe function.

Note: review with hidden whitespaces.