### PR TITLE
Support :where() pseudo-class

### DIFF
--- a/lib/syntax/pseudo/index.js
+++ b/lib/syntax/pseudo/index.js
@@ -39,6 +39,7 @@ export default {
     'any': selectorList,
     '-moz-any': selectorList,
     '-webkit-any': selectorList,
+    'where': selectorList,
     'not': selectorList,
     'nth-child': nth,
     'nth-last-child': nth,


### PR DESCRIPTION
This PR adds support for the CSS `:where()` pseudo-class selector, so a `SelectorList` child instead a `Raw` one is returned. (Like PR #182.)