### PR TITLE
Guard prototype pollution against __proto__ and constructor

### DIFF
--- a/lib/syntax/config/mix.js
+++ b/lib/syntax/config/mix.js
@@ -30,7 +30,8 @@ function assign(dest, src) {
 
 function deepAssign(dest, src) {
     for (const key in src) {
-        if (hasOwnProperty.call(src, key)) {
+        if (hasOwnProperty.call(src, key) &&
+            key !== '__proto__' && key !== 'constructor') {
             if (isObject(dest[key])) {
                 deepAssign(dest[key], copy(src[key]));
             } else {


### PR DESCRIPTION
In deepAssign(), properties are copied without guarding against prototype pollution.