### PR TITLE
Fix for Cannot set property of undefined error.

### DIFF
--- a/lib/utils/List.js
+++ b/lib/utils/List.js
@@ -369,7 +369,7 @@ export class List {
         // prev     next
         this.updateCursors(item, item.prev, item, item.next);
 
-        if (item.prev !== null) {
+        if (item.prev !== null && typeof item.prev !== 'undefined') {
             item.prev.next = item.next;
         } else {
             if (this.head !== item) {
@@ -379,7 +379,7 @@ export class List {
             this.head = item.next;
         }
 
-        if (item.next !== null) {
+        if (item.next !== null && typeof item.next !== 'undefined') {
             item.next.prev = item.prev;
         } else {
             if (this.tail !== item) {


### PR DESCRIPTION
I was getting errors when calling List.remove() that went something like this:
(node:43775) UnhandledPromiseRejectionWarning: TypeError: Cannot set property 'next' of undefined at List.remove (file:///.../node_modules/css-tree/lib/utils/List.js:373:28)

I believe this proposed fix would alleviate those errors.