### PR TITLE
Support :host and :host-context pseudo class selectors

### DIFF
--- a/fixtures/ast/selector/functional-pseudo/host-context.json
+++ b/fixtures/ast/selector/functional-pseudo/host-context.json
@@ -1,0 +1,88 @@
+{
+    "basic": {
+        "source": ":host-context(test)",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "host-context",
+            "children": [
+                {
+                    "type": "Selector",
+                    "children": [
+                        {
+                            "type": "TypeSelector",
+                            "name": "test"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "spaces around selector": {
+        "source": ":host-context(  .a.b  )",
+        "generate": ":host-context(.a.b)",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "host-context",
+            "children": [
+                {
+                    "type": "Selector",
+                    "children": [
+                        {
+                            "type": "ClassSelector",
+                            "name": "a"
+                        },
+                        {
+                            "type": "ClassSelector",
+                            "name": "b"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "should be case insensitive": {
+        "source": ":hOsT-cOntexT(.a)",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "hOsT-cOntexT",
+            "children": [
+                {
+                    "type": "Selector",
+                    "children": [
+                        {
+                            "type": "ClassSelector",
+                            "name": "a"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "error": [
+        {
+            "source": ":host-context(.a{)",
+            "offset": "                ^",
+            "error": "\")\" is expected"
+        },
+        {
+            "source": ":host-context(,.b)",
+            "offset": "              ^",
+            "error": "Selector is expected"
+        },
+        {
+            "source": ":host-context(.a,)",
+            "offset": "                ^",
+            "error": "\")\" is expected"
+        },
+        {
+            "source": ":host-context(var(--test))",
+            "offset": "              ^",
+            "error": "Selector is expected"
+        },
+        {
+            "source": ":host-context(foo,bar)",
+            "offset": "                 ^",
+            "error": "\")\" is expected"
+        }
+    ]
+}

--- a/fixtures/ast/selector/functional-pseudo/host.json
+++ b/fixtures/ast/selector/functional-pseudo/host.json
@@ -17,6 +17,14 @@
             ]
         }
     },
+    "no argument": {
+        "source": ":host",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "host",
+            "children": null
+        }
+    },
     "spaces around selector": {
         "source": ":host(  .a.b  )",
         "generate": ":host(.a.b)",
@@ -59,6 +67,11 @@
         }
     },
     "error": [
+        {
+            "source": ":host()",
+            "offset": "      ^",
+            "error": "Selector is expected"
+        },
         {
             "source": ":host(.a{)",
             "offset": "        ^",

--- a/fixtures/ast/selector/functional-pseudo/host.json
+++ b/fixtures/ast/selector/functional-pseudo/host.json
@@ -1,0 +1,88 @@
+{
+    "basic": {
+        "source": ":host(test)",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "host",
+            "children": [
+                {
+                    "type": "Selector",
+                    "children": [
+                        {
+                            "type": "TypeSelector",
+                            "name": "test"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "spaces around selector": {
+        "source": ":host(  .a.b  )",
+        "generate": ":host(.a.b)",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "host",
+            "children": [
+                {
+                    "type": "Selector",
+                    "children": [
+                        {
+                            "type": "ClassSelector",
+                            "name": "a"
+                        },
+                        {
+                            "type": "ClassSelector",
+                            "name": "b"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "should be case insensitive": {
+        "source": ":hOsT(.a)",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "hOsT",
+            "children": [
+                {
+                    "type": "Selector",
+                    "children": [
+                        {
+                            "type": "ClassSelector",
+                            "name": "a"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "error": [
+        {
+            "source": ":host(.a{)",
+            "offset": "        ^",
+            "error": "\")\" is expected"
+        },
+        {
+            "source": ":host(,.b)",
+            "offset": "      ^",
+            "error": "Selector is expected"
+        },
+        {
+            "source": ":host(.a,)",
+            "offset": "        ^",
+            "error": "\")\" is expected"
+        },
+        {
+            "source": ":host(var(--test))",
+            "offset": "      ^",
+            "error": "Selector is expected"
+        },
+        {
+            "source": ":host(foo,bar)",
+            "offset": "         ^",
+            "error": "\")\" is expected"
+        }
+    ]
+}

--- a/lib/syntax/pseudo/index.js
+++ b/lib/syntax/pseudo/index.js
@@ -44,5 +44,7 @@ export default {
     'nth-last-child': nth,
     'nth-last-of-type': nth,
     'nth-of-type': nth,
-    'slotted': selector
+    'slotted': selector,
+    'host': selector,
+    'host-context': selector
 };


### PR DESCRIPTION
These are defined in https://w3c.github.io/csswg-drafts/css-scoping/#host-selector
- `:host`
- `:host(<compound-selector>)`
- `:host-context(<compound-selector>)`

With this PR, CSSTree will now parse them, instead of returning a `Raw` AST.

Limitations of this PR:
- CSSTree accepts a `<complex-selector>` as the argument to `:host()` and `:host-context()`.  I don’t consider this blocking to this PR as CSSTree has the same problem with `::slotted()` for example. See issue #214.
- `:host-context` should be invalid yet CSSTree does not consider it as such. I don’t consider this blocking to this PR as CSSTree has the same problem with `:has` vs `:has()`. See issue #215.