### PR TITLE
Expose `/lexer/error`, `/lexer/match`, and `/lexer/prepare-tokens` for use in the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,18 @@
     "./utils": {
       "import": "./lib/utils/index.js",
       "require": "./cjs/utils/index.cjs"
+    },
+    "./lexer/error": {
+      "import": "./lib/lexer/error.js",
+      "require": "./cjs/lexer/error.cjs"
+    },
+    "./lexer/match": {
+      "import": "./lib/lexer/match.js",
+      "require": "./cjs/lexer/match.cjs"
+    },
+    "./lexer/prepare-tokens": {
+      "import": "./lib/lexer/prepare-tokens.js",
+      "require": "./cjs/lexer/prepare-tokens.cjs"
     }
   },
   "browser": {


### PR DESCRIPTION
Hi, I'm Yusuke, who develop [Markuplint](https://next.markuplint.dev/) as an HTML and SVG linter.

Thank you for always and the fantastic module.
I use CSSTree at using to validate an attribute value of mainly SVG.

Now I use version `1.x`.
I use part of the functions while importing internal files because I can use detailed processing tokens.

https://github.com/markuplint/markuplint/blob/bf2c9d8a87986e32b567a898ab20ede62ba6c70b/packages/%40markuplint/types/src/css-syntax.ts#L1-L14

However, I can't import those since `v2.x`.
So I would like to ask you to expose the functions I want.

( Or could you create an API?
I want a function that it pass a value and a type identifier and then returns a message with AST and location. )

Please consider.