### PR TITLE
improve performance of ident tokens

### DIFF
--- a/lib/tokenizer/char-code-definitions.js
+++ b/lib/tokenizer/char-code-definitions.js
@@ -35,7 +35,7 @@ export function isLowercaseLetter(code) {
 // letter
 // An uppercase letter or a lowercase letter.
 export function isLetter(code) {
-    return isUppercaseLetter(code) || isLowercaseLetter(code);
+    return isLowercaseLetter(code) || isUppercaseLetter(code);
 }
 
 // non-ASCII code point
@@ -107,8 +107,8 @@ export function isIdentifierStart(first, second, third) {
         // If the second code point is a name-start code point or a U+002D HYPHEN-MINUS,
         // or the second and third code points are a valid escape, return true. Otherwise, return false.
         return (
-            isNameStart(second) ||
             second === 0x002D ||
+            isNameStart(second) ||
             isValidEscape(second, third)
         );
     }


### PR DESCRIPTION
_Unless I overlooked them it appears that there aren't any benchmarks in CSSTree.
So I was unable to measure this change._

1. lower case characters are much more common in CSS source code. Checking these before upper case will result in a faster tokenizer.
2. `--` is a common pattern in custom properties and a cheap check. `-webkit-...` is also common but a slightly more expensive check. This order should be slightly faster. 