### PR TITLE
Update width syntax definition patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -310,7 +310,7 @@
                 "https://developer.mozilla.org/en-US/docs/Web/CSS/width",
                 "https://github.com/csstree/stylelint-validator/issues/29"
             ],
-            "syntax": "| fill | stretch | intrinsic | -moz-max-content | -webkit-max-content | -moz-fit-content | -webkit-fit-content"
+            "syntax": "| fill | stretch | intrinsic | min-intrinsic | -moz-min-content | -moz-max-content | -webkit-max-content | -moz-fit-content | -webkit-fit-content | -moz-available | -webkit-fill-available"
         },
         "min-width": {
             "comment": "extend by non-standard width keywords https://developer.mozilla.org/en-US/docs/Web/CSS/width",


### PR DESCRIPTION
Adds

- `min-intrinsic`
- [`-moz-min-content`](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/66#css)
- `-moz-available`
- `-webkit-fill-available`

check stylelint/stylelint#6511 for context
related: postcss/autoprefixer#1294