### PR TITLE
passthrough env in lexer syntax matching

### DIFF
--- a/fixtures/definition-syntax/env.json
+++ b/fixtures/definition-syntax/env.json
@@ -1,0 +1,17 @@
+{
+    "should pass through (values with `env()` is always valid for now)": {
+        "syntax": "<bar>",
+        "lexer": {
+            "types": {
+                "bar": "foo"
+            }
+        },
+        "valid": [
+            "foo",
+            "env(name)",
+            "env(name) qux",
+            "ENV(name)",
+            "ENV(name) qux"
+        ]
+    }
+}

--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -124,6 +124,12 @@ describe('Lexer#matchProperty()', () => {
                             assert(true);
                             return;
                         }
+
+                        if (
+                            /Matching for a tree with env\(\) is not supported/.test(match.error.message)) {
+                            assert(true);
+                            return;
+                        }
                     }
 
                     assert(match.matched !== null, match.error && match.error.message);

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -54,6 +54,16 @@ function valueHasVar(tokens) {
     return false;
 }
 
+function valueHasEnv(tokens) {
+    for (let i = 0; i < tokens.length; i++) {
+        if (tokens[i].value.toLowerCase() === 'env(') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function buildMatchResult(matched, error, iterations) {
     return {
         matched,
@@ -69,6 +79,10 @@ function matchSyntax(lexer, syntax, value, useCssWideKeywords) {
 
     if (valueHasVar(tokens)) {
         return buildMatchResult(null, new Error('Matching for a tree with var() is not supported'));
+    }
+
+    if (valueHasEnv(tokens)) {
+        return buildMatchResult(null, new Error('Matching for a tree with env() is not supported'));
     }
 
     if (useCssWideKeywords) {


### PR DESCRIPTION
see : https://w3c.github.io/csswg-drafts/css-env/#env-function

The `env()` function is much like the `var()` function.
It is allowed everywhere and it is unknown what the final value will be.