### PR TITLE
add support for typed custom properties

### DIFF
--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -10,7 +10,8 @@ const values = lazyValues({
         return assign(prev, {
             properties: {
                 foo: 'bar',
-                '-baz-foo': 'qux'
+                '-baz-foo': 'qux',
+                '--typed-property': '<color>'
             }
         });
     })
@@ -83,6 +84,27 @@ describe('Lexer#matchProperty()', () => {
 
         assert.strictEqual(match.matched, null);
         assert.strictEqual(match.error.message, 'Lexer matching doesn\'t applicable for custom properties');
+    });
+
+    it('typed custom property', () => {
+        let match;
+
+        match = values.customSyntax.lexer.matchProperty('--typed-property', values.bar);
+
+        assert.strictEqual(match.matched, null);
+        assert.strictEqual(match.error.rawMessage, 'Mismatch');
+        assert.deepStrictEqual({
+            line: match.error.line,
+            column: match.error.column
+        }, {
+            line: 1,
+            column: 1
+        });
+
+        match = values.customSyntax.lexer.matchProperty('--typed-property', 'rgb(0 0 0 / 1)');
+
+        assert(match.matched);
+        assert.strictEqual(match.error, null);
     });
 
     describe('should match css wide keywords', function() {

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -320,8 +320,10 @@ export class Lexer {
         return this.matchProperty(node.property, node.value);
     }
     matchProperty(propertyName, value) {
-        // don't match syntax for a custom property at the moment
-        if (names.property(propertyName).custom) {
+        if (
+            !this.getProperty(propertyName) &&
+            names.property(propertyName).custom
+        ) {
             return buildMatchResult(null, new Error('Lexer matching doesn\'t applicable for custom properties'));
         }
 


### PR DESCRIPTION
The `@property` rule makes it possible to type custom properties.

https://www.w3.org/TR/css-properties-values-api-1/#at-property-rule

This changes makes it possible to validate the syntax for custom properties, only when specific syntax has been added for specific custom properties.

Any unknown custom property will be ignored as it was before this change.