### PR TITLE
Customize tokenizer via the fork API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## next
 
+- Added `tokenize` option to the `fork()` method to allow custom tokenization
 - Added support for the [`@container`](https://drafts.csswg.org/css-contain-3/#container-rule) at-rule
 - Added support for the [`@starting-style`](https://drafts.csswg.org/css-transitions-2/#defining-before-change-style) at-rule
 - Added support for the [`@scope`](https://drafts.csswg.org/css-cascade-6/#scoped-styles) at-rule

--- a/lib/parser/create.js
+++ b/lib/parser/create.js
@@ -57,7 +57,8 @@ function processConfig(config) {
         scope: Object.assign(Object.create(null), config.scope),
         atrule: fetchParseValues(config.atrule),
         pseudo: fetchParseValues(config.pseudo),
-        node: fetchParseValues(config.node)
+        node: fetchParseValues(config.node),
+        tokenize: typeof config.tokenize === 'function' ? config.tokenize : tokenize
     };
 
     for (const [name, context] of Object.entries(config.parseContext)) {
@@ -297,7 +298,7 @@ export function createParser(config) {
         source = source_;
         options = options || {};
 
-        parser.setSource(source, tokenize);
+        parser.setSource(source, parser.tokenize);
         locationMap.setSource(
             source,
             options.offset,

--- a/lib/syntax/config/mix.js
+++ b/lib/syntax/config/mix.js
@@ -110,6 +110,12 @@ export default function mix(dest, src) {
                     ...sliceProps(value, ['name', 'structure', 'parse', 'generate', 'walkContext'])
                 };
                 break;
+
+            case 'tokenize':
+                if (typeof value === 'function') {
+                    result[prop] = value;
+                }
+                break;
         }
     }
 

--- a/lib/syntax/config/parser.js
+++ b/lib/syntax/config/parser.js
@@ -2,6 +2,7 @@ import * as scope from '../scope/index.js';
 import atrule from '../atrule/index.js';
 import pseudo from '../pseudo/index.js';
 import * as node from '../node/index-parse.js';
+import { tokenize } from '../../tokenizer/index.js';
 
 export default {
     parseContext: {
@@ -41,5 +42,6 @@ export default {
     scope,
     atrule,
     pseudo,
-    node
+    node,
+    tokenize
 };

--- a/lib/syntax/create.js
+++ b/lib/syntax/create.js
@@ -16,7 +16,7 @@ function createSyntax(config) {
         lexer: null,
         createLexer: config => new Lexer(config, syntax, syntax.lexer.structure),
 
-        tokenize,
+        tokenize: config.tokenize || tokenize,
         parse,
         generate,
 


### PR DESCRIPTION
Closes https://github.com/csstree/csstree/issues/253

This is a relatively simple PR that allows advanced library users to use a custom tokenizer via the fork API. This PR doesn't change how the base library works, it only affects the forks and makes them even more flexible.

Custom tokenizer function can be a completely new tokenizer or a simple wrapper around CSSTree's tokenizer, the point is that it should meet the following requirements:

1. It should be compatible with the following signature:
   ```ts
   /**
    * CSSTree's tokenizer signature
    *
    * @param source CSS source code to tokenize
    * @param callback Callback which will be invoked when a token is found
    */
   function tokenize(source: string, callback: (tokenType: number, startOffset: number, endOffset: number) => void): void;
   ```
2. It should use with similar token IDs as CSSTree does: https://github.com/csstree/csstree/blob/master/lib/tokenizer/types.js (actually, this is quite natural behaviour, since these are tokens defined by the official specs).

@lahmatiy I think It would be worth making a documentation about the fork API. If you think so, if I have some free time, I will be happy to help you make a basic one in a different PR. These requirements for the custom tokenizer should also be described there.