### PR TITLE
Implement onToken option for parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## next
+
+- Added `onToken` option to the `parse()` method, which can be either an array or a function:
+    - When the value is an array, it is populated with objects `{ type, start, end }` (token type, and its start and end offsets).
+    - When the value is a function, it accepts `type`, `start`, `end`, and `index` parameters, and is invoked with a token API as `this`, enabling advanced token handling (see [onToken](docs/parsing.md#ontoken)). For example, the following demonstrates checking if all block tokens have matching pairs:
+        ```js
+        parse(css, {
+            onToken(type, start, end, index) {
+                if (this.isBlockOpenerTokenType(type)) {
+                    if (this.getBlockPairTokenIndex(index) === -1) {
+                        console.warn('No closing pair for', this.getTokenValue(index), this.getRangeLocation(start, end));
+                    }
+                } else if (this.isBlockCloserTokenType(type)) {
+                    if (this.getBlockPairTokenIndex(index) === -1) {
+                        console.warn('No opening pair for', this.getTokenValue(index), this.getRangeLocation(start, end));
+                    }
+                }
+            }
+        });
+        ```
+- Extended `TokenStream` with the following methods:
+    - `getTokenEnd(tokenIndex)` – returns the token's end offset by index, complementing `getTokenStart(tokenIndex)`
+    - `getTokenType(tokenIndex)` – returns the token's type by index
+    - `isBlockOpenerTokenType(tokenType)` – returns `true` for `<function-token>`, `<(-token>`, `<[-token>`, and `<{-token>`
+    - `isBlockCloserTokenType(tokenType)` – returns `true` for `<)-token>`, `<]-token>`, and `<}-token>`
+    - `getBlockTokenPairIndex(tokenIndex)` – returns the index of the pair token for a block, or `-1` if no pair exists
+
 ## 3.1.0 (December 6, 2024)
 
 - Added support for [boolean expression multiplier](https://drafts.csswg.org/css-values-5/#boolean) in syntax definition, i.e. `<boolean-expr[ test ]>` (#304)

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -42,7 +42,7 @@ Options (optional):
 
 ### context
 
-Type: `string`<br>
+Type: `string`  
 Default: `'stylesheet'`
 
 Defines what part of CSS is parsing.
@@ -64,21 +64,21 @@ Contexts:
 
 ### atrule
 
-Type: `string` or `null`<br>
+Type: `string` or `null`  
 Default: `null`
 
 Using for `atrulePrelude` context to apply atrule specific parse rules.
 
 ### positions
 
-Type: `boolean`<br>
+Type: `boolean`  
 Default: `false`
 
 Specify to store locations of node content in original source. Location is storing as `loc` field of nodes. `loc` property is always `null` when this option is `false`. See structure of [`loc`](ast.md#loc) in AST format description.
 
 ### onParseError
 
-Type: `function(error, fallbackNode)` or `null`<br>
+Type: `function(error, fallbackNode)` or `null`  
 Default: `null`
 
 Parsing is tolerant by default, i.e. any text may to be parsed with no an raised exception. However, mistakes in CSS may make it imposible to parse some part, e.g. a selector or declaration. In that case bad content is wrapping into a `Raw` node and `onParseError` is invoking.
@@ -99,49 +99,49 @@ csstree.parse('example { foo; bar: 1! }', {
 
 ### onComment
 
-Type: `function(value, loc)` or `null`<br>
+Type: `function(value, loc)` or `null`  
 Default: `null`
 
 A handler to call for every comment in parsing source. Value is passing without surrounding `/*` and `*/`. [`loc`](ast.md#loc) will be `null` until `positions` option is set to `true`.
 
-### Token
+### onToken
 
-Type: `function(type, value, loc)` or `null`<br>
+Type: `function(type, start, end, index)` or `Array` or `null`  
 Default: `null`
 
-A handler to call for every non-whitespace, non-comment token in parsing source. [`loc`](ast.md#loc) will be `null` until `positions` option is set to `true`.
+When a function, `onToken` is a handler to call for every token in the parsing source. The arguments are the numeric type of the token, the start offset, the end offset, and the token index. When an array, `onToken` is populated with objects containing the numeric type of the token (`type`), the start offset (`start`), and the end offset (`end`).
 
 ### filename
 
-Type: `string`<br>
+Type: `string`  
 Default: `'<unknown>'`
 
 Filename of source. This value adds to [`loc`](ast.md#loc) as `source` property when `positions` option is `true`. Using for source map generation.
 
 ### offset
 
-Type: `number`<br>
+Type: `number`  
 Default: `0`
 
 Start offset. Useful when parsing a fragment of CSS to store a correct positions for node's [`loc`](ast.md#loc) property.
 
 ### line
 
-Type: `number`<br>
+Type: `number`  
 Default: `1`
 
 Start line number. Useful when parsing fragment of CSS to store correct positions in node's [`loc`](ast.md#loc) property.
 
 ### column
 
-Type: `number`<br>
+Type: `number`  
 Default: `1`
 
 Start column number. Useful when parsing fragment of CSS to store correct positions in node's `loc` property.
 
 ### parseAtrulePrelude
 
-Type: `boolean`<br>
+Type: `boolean`  
 Default: `true`
 
 Defines to parse an at-rule prelude in details (represents as `AtruleExpresion`, `MediaQueryList` or `SelectorList` if any). Otherwise, represents prelude as `Raw` node.
@@ -187,7 +187,7 @@ csstree.parse('@example 1 2;', {
 
 ### parseRulePrelude
 
-Type: `boolean`<br>
+Type: `boolean`  
 Default: `true`
 
 Defines to parse a rule prelude in details or left unparsed (represents as `Raw` node).
@@ -241,7 +241,7 @@ csstree.parse('.foo {}', {
 
 ### parseValue
 
-Type: `boolean`<br>
+Type: `boolean`  
 Default: `true`
 
 Defines to parse a declaration value in details (represents as `Value`). Otherwise represents value as `Raw` node.
@@ -282,7 +282,7 @@ csstree.parse('color: #aabbcc', {
 
 ### parseCustomProperty
 
-Type: `boolean`<br>
+Type: `boolean`  
 Default: `false`
 
 Defines to parse a custom property value and a `var()` fallback in details (represents as `Value`). Otherwise represents value as `Raw` node.

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -42,7 +42,7 @@ Options (optional):
 
 ### context
 
-Type: `string`
+Type: `string`<br>
 Default: `'stylesheet'`
 
 Defines what part of CSS is parsing.
@@ -64,21 +64,21 @@ Contexts:
 
 ### atrule
 
-Type: `string` or `null`
+Type: `string` or `null`<br>
 Default: `null`
 
 Using for `atrulePrelude` context to apply atrule specific parse rules.
 
 ### positions
 
-Type: `boolean`
+Type: `boolean`<br>
 Default: `false`
 
 Specify to store locations of node content in original source. Location is storing as `loc` field of nodes. `loc` property is always `null` when this option is `false`. See structure of [`loc`](ast.md#loc) in AST format description.
 
 ### onParseError
 
-Type: `function(error, fallbackNode)` or `null`
+Type: `function(error, fallbackNode)` or `null`<br>
 Default: `null`
 
 Parsing is tolerant by default, i.e. any text may to be parsed with no an raised exception. However, mistakes in CSS may make it imposible to parse some part, e.g. a selector or declaration. In that case bad content is wrapping into a `Raw` node and `onParseError` is invoking.
@@ -99,49 +99,49 @@ csstree.parse('example { foo; bar: 1! }', {
 
 ### onComment
 
-Type: `function(value, loc)` or `null`
+Type: `function(value, loc)` or `null`<br>
 Default: `null`
 
 A handler to call for every comment in parsing source. Value is passing without surrounding `/*` and `*/`. [`loc`](ast.md#loc) will be `null` until `positions` option is set to `true`.
 
 ### Token
 
-Type: `function(type, value, loc)` or `null`
+Type: `function(type, value, loc)` or `null`<br>
 Default: `null`
 
 A handler to call for every non-whitespace, non-comment token in parsing source. [`loc`](ast.md#loc) will be `null` until `positions` option is set to `true`.
 
 ### filename
 
-Type: `string`
+Type: `string`<br>
 Default: `'<unknown>'`
 
 Filename of source. This value adds to [`loc`](ast.md#loc) as `source` property when `positions` option is `true`. Using for source map generation.
 
 ### offset
 
-Type: `number`
+Type: `number`<br>
 Default: `0`
 
 Start offset. Useful when parsing a fragment of CSS to store a correct positions for node's [`loc`](ast.md#loc) property.
 
 ### line
 
-Type: `number`
+Type: `number`<br>
 Default: `1`
 
 Start line number. Useful when parsing fragment of CSS to store correct positions in node's [`loc`](ast.md#loc) property.
 
 ### column
 
-Type: `number`
+Type: `number`<br>
 Default: `1`
 
 Start column number. Useful when parsing fragment of CSS to store correct positions in node's `loc` property.
 
 ### parseAtrulePrelude
 
-Type: `boolean`
+Type: `boolean`<br>
 Default: `true`
 
 Defines to parse an at-rule prelude in details (represents as `AtruleExpresion`, `MediaQueryList` or `SelectorList` if any). Otherwise, represents prelude as `Raw` node.
@@ -187,7 +187,7 @@ csstree.parse('@example 1 2;', {
 
 ### parseRulePrelude
 
-Type: `boolean`
+Type: `boolean`<br>
 Default: `true`
 
 Defines to parse a rule prelude in details or left unparsed (represents as `Raw` node).
@@ -241,7 +241,7 @@ csstree.parse('.foo {}', {
 
 ### parseValue
 
-Type: `boolean`
+Type: `boolean`<br>
 Default: `true`
 
 Defines to parse a declaration value in details (represents as `Value`). Otherwise represents value as `Raw` node.
@@ -282,7 +282,7 @@ csstree.parse('color: #aabbcc', {
 
 ### parseCustomProperty
 
-Type: `boolean`
+Type: `boolean`<br>
 Default: `false`
 
 Defines to parse a custom property value and a `var()` fallback in details (represents as `Value`). Otherwise represents value as `Raw` node.

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -27,6 +27,7 @@ Options (optional):
 - [atrule](#atrule)
 - [positions](#positions)
 - [onComment](#oncomment)
+- [onToken](#ontoken)
 - [onParseError](#onparseerror)
 - [filename](#filename)
 - [offset](#offset)
@@ -41,7 +42,7 @@ Options (optional):
 
 ### context
 
-Type: `string`  
+Type: `string`
 Default: `'stylesheet'`
 
 Defines what part of CSS is parsing.
@@ -63,21 +64,21 @@ Contexts:
 
 ### atrule
 
-Type: `string` or `null`  
+Type: `string` or `null`
 Default: `null`
 
 Using for `atrulePrelude` context to apply atrule specific parse rules.
 
 ### positions
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Specify to store locations of node content in original source. Location is storing as `loc` field of nodes. `loc` property is always `null` when this option is `false`. See structure of [`loc`](ast.md#loc) in AST format description.
 
 ### onParseError
 
-Type: `function(error, fallbackNode)` or `null`  
+Type: `function(error, fallbackNode)` or `null`
 Default: `null`
 
 Parsing is tolerant by default, i.e. any text may to be parsed with no an raised exception. However, mistakes in CSS may make it imposible to parse some part, e.g. a selector or declaration. In that case bad content is wrapping into a `Raw` node and `onParseError` is invoking.
@@ -98,42 +99,49 @@ csstree.parse('example { foo; bar: 1! }', {
 
 ### onComment
 
-Type: `function(value, loc)` or `null`  
+Type: `function(value, loc)` or `null`
 Default: `null`
 
 A handler to call for every comment in parsing source. Value is passing without surrounding `/*` and `*/`. [`loc`](ast.md#loc) will be `null` until `positions` option is set to `true`.
 
+### Token
+
+Type: `function(type, value, loc)` or `null`
+Default: `null`
+
+A handler to call for every non-whitespace, non-comment token in parsing source. [`loc`](ast.md#loc) will be `null` until `positions` option is set to `true`.
+
 ### filename
 
-Type: `string`  
+Type: `string`
 Default: `'<unknown>'`
 
 Filename of source. This value adds to [`loc`](ast.md#loc) as `source` property when `positions` option is `true`. Using for source map generation.
 
 ### offset
 
-Type: `number`  
+Type: `number`
 Default: `0`
 
 Start offset. Useful when parsing a fragment of CSS to store a correct positions for node's [`loc`](ast.md#loc) property.
 
 ### line
 
-Type: `number`  
+Type: `number`
 Default: `1`
 
 Start line number. Useful when parsing fragment of CSS to store correct positions in node's [`loc`](ast.md#loc) property.
 
 ### column
 
-Type: `number`  
+Type: `number`
 Default: `1`
 
 Start column number. Useful when parsing fragment of CSS to store correct positions in node's `loc` property.
 
 ### parseAtrulePrelude
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 Defines to parse an at-rule prelude in details (represents as `AtruleExpresion`, `MediaQueryList` or `SelectorList` if any). Otherwise, represents prelude as `Raw` node.
@@ -179,7 +187,7 @@ csstree.parse('@example 1 2;', {
 
 ### parseRulePrelude
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 Defines to parse a rule prelude in details or left unparsed (represents as `Raw` node).
@@ -233,7 +241,7 @@ csstree.parse('.foo {}', {
 
 ### parseValue
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 Defines to parse a declaration value in details (represents as `Value`). Otherwise represents value as `Raw` node.
@@ -274,7 +282,7 @@ csstree.parse('color: #aabbcc', {
 
 ### parseCustomProperty
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Defines to parse a custom property value and a `var()` fallback in details (represents as `Value`). Otherwise represents value as `Raw` node.

--- a/lib/__tests/parse.js
+++ b/lib/__tests/parse.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import fs from 'fs';
 import { parse, walk, List } from 'css-tree';
 import { forEachTest as forEachAstTest } from './fixture/ast.js';
+import { tokenTypes } from '../tokenizer/index.js';
 
 const genericTypesFixture = JSON.parse(fs.readFileSync('./fixtures/definition-syntax-match/generic.json'));
 const stringifyWithNoLoc = ast => JSON.stringify(ast, (key, value) => key !== 'loc' ? value : undefined, 4);
@@ -374,71 +375,66 @@ describe('parse', () => {
     describe('onToken', () => {
         const source = '/*123*/.foo[a=/* 234 */] {\n  color: red;} /*567*';
 
-        it('with no locations', () => {
+        it('as function', () => {
             const actual = [];
             parse(source, {
-                onToken(type, value, loc) {
-                    actual.push({ type, value, loc });
+                onToken(type, start, end) {
+                    actual.push({ type, start, end });
                 }
             });
 
             assert.deepStrictEqual(actual, [
-                { type: 'delim-token', value: '.', loc: null },
-                { type: 'ident-token', value: 'foo', loc: null },
-                { type: '[-token', value: '[', loc: null },
-                { type: 'ident-token', value: 'a', loc: null },
-                { type: 'delim-token', value: '=', loc: null },
-                { type: ']-token', value: ']', loc: null },
-                { type: '{-token', value: '{', loc: null },
-                { type: 'ident-token', value: 'color', loc: null },
-                { type: 'colon-token', value: ':', loc: null },
-                { type: 'ident-token', value: 'red', loc: null },
-                { type: 'semicolon-token', value: ';', loc: null },
-                { type: '}-token', value: '}', loc: null }
+                { type: tokenTypes.Comment, start: 0, end: 7 },
+                { type: tokenTypes.Delim, start: 7, end: 8 },
+                { type: tokenTypes.Ident, start: 8, end: 11 },
+                { type: tokenTypes.LeftSquareBracket, start: 11, end: 12 },
+                { type: tokenTypes.Ident, start: 12, end: 13 },
+                { type: tokenTypes.Delim, start: 13, end: 14 },
+                { type: tokenTypes.Comment, start: 14, end: 23 },
+                { type: tokenTypes.RightSquareBracket, start: 23, end: 24 },
+                { type: tokenTypes.WhiteSpace, start: 24, end: 25 },
+                { type: tokenTypes.LeftCurlyBracket, start: 25, end: 26 },
+                { type: tokenTypes.WhiteSpace, start: 26, end: 29 },
+                { type: tokenTypes.Ident, start: 29, end: 34 },
+                { type: tokenTypes.Colon, start: 34, end: 35 },
+                { type: tokenTypes.WhiteSpace, start: 35, end: 36 },
+                { type: tokenTypes.Ident, start: 36, end: 39 },
+                { type: tokenTypes.Semicolon, start: 39, end: 40 },
+                { type: tokenTypes.RightCurlyBracket, start: 40, end: 41 },
+                { type: tokenTypes.WhiteSpace, start: 41, end: 42 },
+                { type: tokenTypes.Comment, start: 42, end: 48 }
             ]);
         });
 
-        it('with locations', () => {
+        it('as array', () => {
             const actual = [];
-            const offsetToPos = offset => {
-                const lines = source.slice(0, offset).split('\n');
-                return {
-                    offset,
-                    line: lines.length,
-                    column: lines.pop().length + 1
-                };
-            };
-            const loc = (start, end) => {
-                return {
-                    source: 'test.css',
-                    start: offsetToPos(start),
-                    end: offsetToPos(end)
-                };
-            };
-
             parse(source, {
-                filename: 'test.css',
-                positions: true,
-                onToken(type, value, loc) {
-                    actual.push({ type, value, loc });
-                }
+                onToken: actual
             });
 
             assert.deepStrictEqual(actual, [
-                { type: 'delim-token', value: '.', loc: loc(7, 8) },
-                { type: 'ident-token', value: 'foo', loc: loc(8, 11) },
-                { type: '[-token', value: '[', loc: loc(11, 12) },
-                { type: 'ident-token', value: 'a', loc: loc(12, 13) },
-                { type: 'delim-token', value: '=', loc: loc(13, 14) },
-                { type: ']-token', value: ']', loc: loc(23, 24) },
-                { type: '{-token', value: '{', loc: loc(25, 26) },
-                { type: 'ident-token', value: 'color', loc: loc(29, 34) },
-                { type: 'colon-token', value: ':', loc: loc(34, 35) },
-                { type: 'ident-token', value: 'red', loc: loc(36, 39) },
-                { type: 'semicolon-token', value: ';', loc: loc(39, 40) },
-                { type: '}-token', value: '}', loc: loc(40, 41) }
+                { type: tokenTypes.Comment, start: 0, end: 7 },
+                { type: tokenTypes.Delim, start: 7, end: 8 },
+                { type: tokenTypes.Ident, start: 8, end: 11 },
+                { type: tokenTypes.LeftSquareBracket, start: 11, end: 12 },
+                { type: tokenTypes.Ident, start: 12, end: 13 },
+                { type: tokenTypes.Delim, start: 13, end: 14 },
+                { type: tokenTypes.Comment, start: 14, end: 23 },
+                { type: tokenTypes.RightSquareBracket, start: 23, end: 24 },
+                { type: tokenTypes.WhiteSpace, start: 24, end: 25 },
+                { type: tokenTypes.LeftCurlyBracket, start: 25, end: 26 },
+                { type: tokenTypes.WhiteSpace, start: 26, end: 29 },
+                { type: tokenTypes.Ident, start: 29, end: 34 },
+                { type: tokenTypes.Colon, start: 34, end: 35 },
+                { type: tokenTypes.WhiteSpace, start: 35, end: 36 },
+                { type: tokenTypes.Ident, start: 36, end: 39 },
+                { type: tokenTypes.Semicolon, start: 39, end: 40 },
+                { type: tokenTypes.RightCurlyBracket, start: 40, end: 41 },
+                { type: tokenTypes.WhiteSpace, start: 41, end: 42 },
+                { type: tokenTypes.Comment, start: 42, end: 48 }
             ]);
         });
+
     });
 
     describe('positions', () => {

--- a/lib/__tests/parse.js
+++ b/lib/__tests/parse.js
@@ -371,6 +371,76 @@ describe('parse', () => {
         });
     });
 
+    describe('onToken', () => {
+        const source = '/*123*/.foo[a=/* 234 */] {\n  color: red;} /*567*';
+
+        it('with no locations', () => {
+            const actual = [];
+            parse(source, {
+                onToken(type, value, loc) {
+                    actual.push({ type, value, loc });
+                }
+            });
+
+            assert.deepStrictEqual(actual, [
+                { type: 'delim-token', value: '.', loc: null },
+                { type: 'ident-token', value: 'foo', loc: null },
+                { type: '[-token', value: '[', loc: null },
+                { type: 'ident-token', value: 'a', loc: null },
+                { type: 'delim-token', value: '=', loc: null },
+                { type: ']-token', value: ']', loc: null },
+                { type: '{-token', value: '{', loc: null },
+                { type: 'ident-token', value: 'color', loc: null },
+                { type: 'colon-token', value: ':', loc: null },
+                { type: 'ident-token', value: 'red', loc: null },
+                { type: 'semicolon-token', value: ';', loc: null },
+                { type: '}-token', value: '}', loc: null }
+            ]);
+        });
+
+        it('with locations', () => {
+            const actual = [];
+            const offsetToPos = offset => {
+                const lines = source.slice(0, offset).split('\n');
+                return {
+                    offset,
+                    line: lines.length,
+                    column: lines.pop().length + 1
+                };
+            };
+            const loc = (start, end) => {
+                return {
+                    source: 'test.css',
+                    start: offsetToPos(start),
+                    end: offsetToPos(end)
+                };
+            };
+
+            parse(source, {
+                filename: 'test.css',
+                positions: true,
+                onToken(type, value, loc) {
+                    actual.push({ type, value, loc });
+                }
+            });
+
+            assert.deepStrictEqual(actual, [
+                { type: 'delim-token', value: '.', loc: loc(7, 8) },
+                { type: 'ident-token', value: 'foo', loc: loc(8, 11) },
+                { type: '[-token', value: '[', loc: loc(11, 12) },
+                { type: 'ident-token', value: 'a', loc: loc(12, 13) },
+                { type: 'delim-token', value: '=', loc: loc(13, 14) },
+                { type: ']-token', value: ']', loc: loc(23, 24) },
+                { type: '{-token', value: '{', loc: loc(25, 26) },
+                { type: 'ident-token', value: 'color', loc: loc(29, 34) },
+                { type: 'colon-token', value: ':', loc: loc(34, 35) },
+                { type: 'ident-token', value: 'red', loc: loc(36, 39) },
+                { type: 'semicolon-token', value: ';', loc: loc(39, 40) },
+                { type: '}-token', value: '}', loc: loc(40, 41) }
+            ]);
+        });
+    });
+
     describe('positions', () => {
         it('should start with line 1 column 1 by default', () => {
             const positions = [];

--- a/lib/__tests/parse.js
+++ b/lib/__tests/parse.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import fs from 'fs';
 import { parse, walk, List } from 'css-tree';
 import { forEachTest as forEachAstTest } from './fixture/ast.js';
-import { tokenTypes } from '../tokenizer/index.js';
+import { tokenTypes, tokenNames, OffsetToLocation, TokenStream, tokenize } from '../tokenizer/index.js';
 
 const genericTypesFixture = JSON.parse(fs.readFileSync('./fixtures/definition-syntax-match/generic.json'));
 const stringifyWithNoLoc = ast => JSON.stringify(ast, (key, value) => key !== 'loc' ? value : undefined, 4);
@@ -374,36 +374,88 @@ describe('parse', () => {
 
     describe('onToken', () => {
         const source = '/*123*/.foo[a=/* 234 */] {\n  color: red;} /*567*';
+        const expected = [
+            { type: tokenTypes.Comment, start: 0, end: 7 },
+            { type: tokenTypes.Delim, start: 7, end: 8 },
+            { type: tokenTypes.Ident, start: 8, end: 11 },
+            { type: tokenTypes.LeftSquareBracket, start: 11, end: 12 },
+            { type: tokenTypes.Ident, start: 12, end: 13 },
+            { type: tokenTypes.Delim, start: 13, end: 14 },
+            { type: tokenTypes.Comment, start: 14, end: 23 },
+            { type: tokenTypes.RightSquareBracket, start: 23, end: 24 },
+            { type: tokenTypes.WhiteSpace, start: 24, end: 25 },
+            { type: tokenTypes.LeftCurlyBracket, start: 25, end: 26 },
+            { type: tokenTypes.WhiteSpace, start: 26, end: 29 },
+            { type: tokenTypes.Ident, start: 29, end: 34 },
+            { type: tokenTypes.Colon, start: 34, end: 35 },
+            { type: tokenTypes.WhiteSpace, start: 35, end: 36 },
+            { type: tokenTypes.Ident, start: 36, end: 39 },
+            { type: tokenTypes.Semicolon, start: 39, end: 40 },
+            { type: tokenTypes.RightCurlyBracket, start: 40, end: 41 },
+            { type: tokenTypes.WhiteSpace, start: 41, end: 42 },
+            { type: tokenTypes.Comment, start: 42, end: 48 }
+        ];
 
         it('as function', () => {
             const actual = [];
             parse(source, {
-                onToken(type, start, end) {
-                    actual.push({ type, start, end });
+                onToken(type, start, end, index) {
+                    actual.push({ type, start, end, index });
                 }
             });
 
-            assert.deepStrictEqual(actual, [
-                { type: tokenTypes.Comment, start: 0, end: 7 },
-                { type: tokenTypes.Delim, start: 7, end: 8 },
-                { type: tokenTypes.Ident, start: 8, end: 11 },
-                { type: tokenTypes.LeftSquareBracket, start: 11, end: 12 },
-                { type: tokenTypes.Ident, start: 12, end: 13 },
-                { type: tokenTypes.Delim, start: 13, end: 14 },
-                { type: tokenTypes.Comment, start: 14, end: 23 },
-                { type: tokenTypes.RightSquareBracket, start: 23, end: 24 },
-                { type: tokenTypes.WhiteSpace, start: 24, end: 25 },
-                { type: tokenTypes.LeftCurlyBracket, start: 25, end: 26 },
-                { type: tokenTypes.WhiteSpace, start: 26, end: 29 },
-                { type: tokenTypes.Ident, start: 29, end: 34 },
-                { type: tokenTypes.Colon, start: 34, end: 35 },
-                { type: tokenTypes.WhiteSpace, start: 35, end: 36 },
-                { type: tokenTypes.Ident, start: 36, end: 39 },
-                { type: tokenTypes.Semicolon, start: 39, end: 40 },
-                { type: tokenTypes.RightCurlyBracket, start: 40, end: 41 },
-                { type: tokenTypes.WhiteSpace, start: 41, end: 42 },
-                { type: tokenTypes.Comment, start: 42, end: 48 }
-            ]);
+            assert.deepStrictEqual(actual, expected.map((token, index) => ({
+                index,
+                ...token
+            })));
+        });
+
+        it('as function with API', () => {
+            const filename = 'test.css';
+            const offsetToLocation = new OffsetToLocation(source);
+            const tokenStream = new TokenStream(source, tokenize);
+            const actual = [];
+
+            parse(source, {
+                filename,
+                onToken(type, start, end, index) {
+                    actual.push({
+                        index,
+                        filename: this.filename,
+                        source: this.source,
+                        tokenCount: this.tokenCount,
+                        type: this.getTokenType(index),
+                        typeName: this.getTokenTypeName(index),
+                        isBlockOpenerTokenType: this.isBlockOpenerTokenType(type),
+                        isBlockCloserTokenType: this.isBlockCloserTokenType(type),
+                        balance: this.balance[index],
+                        blockTokenPairIndex: this.getBlockTokenPairIndex(index),
+                        start: this.getTokenStart(index),
+                        end: this.getTokenEnd(index),
+                        value: this.getTokenValue(index),
+                        substring: this.substring(start, end),
+                        location: this.getLocation(start),
+                        rangeLocation: this.getRangeLocation(start, end)
+                    });
+                }
+            });
+
+            assert.deepStrictEqual(actual, expected.map((token, index) => ({
+                index,
+                filename,
+                source,
+                tokenCount: tokenStream.tokenCount,
+                typeName: tokenNames[token.type],
+                isBlockOpenerTokenType: [tokenTypes.Function, tokenTypes.LeftParenthesis, tokenTypes.LeftSquareBracket, tokenTypes.LeftCurlyBracket].includes(token.type),
+                isBlockCloserTokenType: [tokenTypes.RightParenthesis, tokenTypes.RightSquareBracket, tokenTypes.RightCurlyBracket].includes(token.type),
+                balance: tokenStream.balance[index],
+                blockTokenPairIndex: tokenStream.getBlockTokenPairIndex(index),
+                value: source.substring(token.start, token.end),
+                substring: source.substring(token.start, token.end),
+                location: offsetToLocation.getLocation(token.start, filename),
+                rangeLocation: offsetToLocation.getLocationRange(token.start, token.end, filename),
+                ...token
+            })));
         });
 
         it('as array', () => {
@@ -412,27 +464,7 @@ describe('parse', () => {
                 onToken: actual
             });
 
-            assert.deepStrictEqual(actual, [
-                { type: tokenTypes.Comment, start: 0, end: 7 },
-                { type: tokenTypes.Delim, start: 7, end: 8 },
-                { type: tokenTypes.Ident, start: 8, end: 11 },
-                { type: tokenTypes.LeftSquareBracket, start: 11, end: 12 },
-                { type: tokenTypes.Ident, start: 12, end: 13 },
-                { type: tokenTypes.Delim, start: 13, end: 14 },
-                { type: tokenTypes.Comment, start: 14, end: 23 },
-                { type: tokenTypes.RightSquareBracket, start: 23, end: 24 },
-                { type: tokenTypes.WhiteSpace, start: 24, end: 25 },
-                { type: tokenTypes.LeftCurlyBracket, start: 25, end: 26 },
-                { type: tokenTypes.WhiteSpace, start: 26, end: 29 },
-                { type: tokenTypes.Ident, start: 29, end: 34 },
-                { type: tokenTypes.Colon, start: 34, end: 35 },
-                { type: tokenTypes.WhiteSpace, start: 35, end: 36 },
-                { type: tokenTypes.Ident, start: 36, end: 39 },
-                { type: tokenTypes.Semicolon, start: 39, end: 40 },
-                { type: tokenTypes.RightCurlyBracket, start: 40, end: 41 },
-                { type: tokenTypes.WhiteSpace, start: 41, end: 42 },
-                { type: tokenTypes.Comment, start: 42, end: 48 }
-            ]);
+            assert.deepStrictEqual(actual, expected);
         });
 
     });

--- a/lib/__tests/tokenizer.js
+++ b/lib/__tests/tokenizer.js
@@ -155,6 +155,30 @@ describe('tokenize/stream', () => {
         assert.strictEqual(stream.eof, true);
     });
 
+    describe('getBlockTokenPairIndex()', () => {
+        it('all blocks closed', () => {
+            const stream = createStream('start fn({[()]}) end');
+            const actual = [];
+
+            stream.forEachToken((type, start, end, index) => {
+                actual.push(stream.getBlockTokenPairIndex(index));
+            });
+
+            assert.deepStrictEqual(actual, [-1, -1, 9, 8, 7, 6, 5, 4, 3, 2, -1, -1]);
+        });
+
+        it('non-closed blocks', () => {
+            const stream = createStream('start fn(]}()[{)');
+            const actual = [];
+
+            stream.forEachToken((type, start, end, index) => {
+                actual.push(stream.getBlockTokenPairIndex(index));
+            });
+
+            assert.deepStrictEqual(actual, [-1, -1, -1, -1, -1, 6, 5, -1, -1, -1]);
+        });
+    });
+
     describe('Raw', () => {
         const LEFTCURLYBRACKET = 0x007B; // U+007B LEFT CURLY BRACKET ({)
         const SEMICOLON = 0x003B;        // U+003B SEMICOLON (;)

--- a/lib/parser/create.js
+++ b/lib/parser/create.js
@@ -321,7 +321,7 @@ export function createParser(config) {
             throw new Error('Unknown context `' + context + '`');
         }
 
-        if (typeof onComment === 'function' || typeof onToken === 'function') {
+        if (typeof onComment === 'function' || typeof onToken === 'function' || Array.isArray(onToken)) {
             parser.forEachToken((type, start, end) => {
                 if (type === Comment) {
                     if (onComment) {
@@ -332,18 +332,12 @@ export function createParser(config) {
 
                         onComment(value, loc);
                     }
-                    return;
                 }
 
-                if (type === WhiteSpace) {
-                    return;
-                }
-
-                if (onToken) {
-                    const loc = parser.getLocation(start, end);
-                    const value = source.slice(start, end);
-
-                    onToken(tokenNames[type], value, loc);
+                if (typeof onToken === 'function') {
+                    onToken(type, start, end);
+                } else if (Array.isArray(onToken)) {
+                    onToken.push({ type, start, end });
                 }
             });
         }

--- a/lib/parser/create.js
+++ b/lib/parser/create.js
@@ -315,21 +315,35 @@ export function createParser(config) {
         parser.parseValue = 'parseValue' in options ? Boolean(options.parseValue) : true;
         parser.parseCustomProperty = 'parseCustomProperty' in options ? Boolean(options.parseCustomProperty) : false;
 
-        const { context = 'default', onComment } = options;
+        const { context = 'default', onComment, onToken } = options;
 
         if (context in parser.context === false) {
             throw new Error('Unknown context `' + context + '`');
         }
 
-        if (typeof onComment === 'function') {
+        if (typeof onComment === 'function' || typeof onToken === 'function') {
             parser.forEachToken((type, start, end) => {
                 if (type === Comment) {
-                    const loc = parser.getLocation(start, end);
-                    const value = cmpStr(source, end - 2, end, '*/')
-                        ? source.slice(start + 2, end - 2)
-                        : source.slice(start + 2, end);
+                    if (onComment) {
+                        const loc = parser.getLocation(start, end);
+                        const value = cmpStr(source, end - 2, end, '*/')
+                            ? source.slice(start + 2, end - 2)
+                            : source.slice(start + 2, end);
 
-                    onComment(value, loc);
+                        onComment(value, loc);
+                    }
+                    return;
+                }
+
+                if (type === WhiteSpace) {
+                    return;
+                }
+
+                if (onToken) {
+                    const loc = parser.getLocation(start, end);
+                    const value = source.slice(start, end);
+
+                    onToken(tokenNames[type], value, loc);
                 }
             });
         }

--- a/lib/parser/create.js
+++ b/lib/parser/create.js
@@ -292,6 +292,36 @@ export function createParser(config) {
             );
         }
     });
+    const createTokenIterateAPI = () => ({
+        filename,
+        source,
+        tokenCount: parser.tokenCount,
+
+        getTokenType: (index) =>
+            parser.getTokenType(index),
+        getTokenTypeName: (index) =>
+            tokenNames[parser.getTokenType(index)],
+        getTokenStart: (index) =>
+            parser.getTokenStart(index),
+        getTokenEnd: (index) =>
+            parser.getTokenEnd(index),
+        getTokenValue: (index) =>
+            parser.source.substring(parser.getTokenStart(index), parser.getTokenEnd(index)),
+
+        substring: (start, end) =>
+            parser.source.substring(start, end),
+
+        balance: parser.balance.subarray(0, parser.tokenCount + 1),
+        isBlockOpenerTokenType: parser.isBlockOpenerTokenType,
+        isBlockCloserTokenType: parser.isBlockCloserTokenType,
+        getBlockTokenPairIndex: (index) =>
+            parser.getBlockTokenPairIndex(index),
+
+        getLocation: (offset) =>
+            locationMap.getLocation(offset, filename),
+        getRangeLocation: (start, end) =>
+            locationMap.getLocationRange(start, end, filename)
+    });
 
     const parse = function(source_, options) {
         source = source_;
@@ -321,23 +351,23 @@ export function createParser(config) {
             throw new Error('Unknown context `' + context + '`');
         }
 
-        if (typeof onComment === 'function' || typeof onToken === 'function' || Array.isArray(onToken)) {
+        if (Array.isArray(onToken)) {
+            parser.forEachToken((type, start, end) => {
+                onToken.push({ type, start, end });
+            });
+        } else if (typeof onToken === 'function') {
+            parser.forEachToken(onToken.bind(createTokenIterateAPI()));
+        }
+
+        if (typeof onComment === 'function') {
             parser.forEachToken((type, start, end) => {
                 if (type === Comment) {
-                    if (onComment) {
-                        const loc = parser.getLocation(start, end);
-                        const value = cmpStr(source, end - 2, end, '*/')
-                            ? source.slice(start + 2, end - 2)
-                            : source.slice(start + 2, end);
+                    const loc = parser.getLocation(start, end);
+                    const value = cmpStr(source, end - 2, end, '*/')
+                        ? source.slice(start + 2, end - 2)
+                        : source.slice(start + 2, end);
 
-                        onComment(value, loc);
-                    }
-                }
-
-                if (typeof onToken === 'function') {
-                    onToken(type, start, end);
-                } else if (Array.isArray(onToken)) {
-                    onToken.push({ type, start, end });
+                    onComment(value, loc);
                 }
             });
         }

--- a/lib/tokenizer/TokenStream.js
+++ b/lib/tokenizer/TokenStream.js
@@ -17,14 +17,25 @@ import {
 
 const OFFSET_MASK = 0x00FFFFFF;
 const TYPE_SHIFT = 24;
+const BLOCK_OPEN_TOKEN = 1;
+const BLOCK_CLOSE_TOKEN = 2;
 const balancePair = new Uint8Array(32); // 32b of memory ought to be enough for anyone (any number of tokens)
 balancePair[FunctionToken] = RightParenthesis;
 balancePair[LeftParenthesis] = RightParenthesis;
 balancePair[LeftSquareBracket] = RightSquareBracket;
 balancePair[LeftCurlyBracket] = RightCurlyBracket;
 
-function isBlockOpenerToken(tokenType) {
-    return balancePair[tokenType] !== 0;
+const blockTokens = new Uint8Array(32);
+blockTokens[FunctionToken] = BLOCK_OPEN_TOKEN;
+blockTokens[LeftParenthesis] = BLOCK_OPEN_TOKEN;
+blockTokens[LeftSquareBracket] = BLOCK_OPEN_TOKEN;
+blockTokens[LeftCurlyBracket] = BLOCK_OPEN_TOKEN;
+blockTokens[RightParenthesis] = BLOCK_CLOSE_TOKEN;
+blockTokens[RightSquareBracket] = BLOCK_CLOSE_TOKEN;
+blockTokens[RightCurlyBracket] = BLOCK_CLOSE_TOKEN;
+
+function boundIndex(index, min, max) {
+    return index < min ? min : index > max ? max : index;
 }
 
 export class TokenStream {
@@ -76,7 +87,7 @@ export class TokenStream {
                 // pop state
                 balanceStart = prevBalanceStart;
                 balanceCloseType = balancePair[offsetAndType[prevBalanceStart] >> TYPE_SHIFT];
-            } else if (isBlockOpenerToken(type)) { // check for FunctionToken, <(-token>, <[-token> and <{-token>
+            } else if (this.isBlockOpenerTokenType(type)) { // check for FunctionToken, <(-token>, <[-token> and <{-token>
                 // push state
                 balanceStart = index;
                 balanceCloseType = balancePair[type];
@@ -194,14 +205,53 @@ export class TokenStream {
 
         return this.firstCharOffset;
     }
+    getTokenEnd(tokenIndex) {
+        if (tokenIndex === this.tokenIndex) {
+            return this.tokenEnd;
+        }
+
+        return this.offsetAndType[boundIndex(tokenIndex, 0, this.tokenCount)] & OFFSET_MASK;
+    }
+    getTokenType(tokenIndex) {
+        if (tokenIndex === this.tokenIndex) {
+            return this.tokenType;
+        }
+
+        return this.offsetAndType[boundIndex(tokenIndex, 0, this.tokenCount)] >> TYPE_SHIFT;
+    }
     substrToCursor(start) {
         return this.source.substring(start, this.tokenStart);
     }
 
-    isBalanceEdge(pos) {
-        return this.balance[this.tokenIndex] < pos;
-        // return this.balance[this.balance[pos]] !== this.tokenIndex;
+    isBlockOpenerTokenType(tokenType) {
+        return blockTokens[tokenType] === BLOCK_OPEN_TOKEN;
     }
+    isBlockCloserTokenType(tokenType) {
+        return blockTokens[tokenType] === BLOCK_CLOSE_TOKEN;
+    }
+    getBlockTokenPairIndex(tokenIndex) {
+        const type = this.getTokenType(tokenIndex);
+
+        if (blockTokens[type] === 1) {
+            // block open token
+            const pairIndex = this.balance[tokenIndex];
+            const closeType = this.getTokenType(pairIndex);
+
+            return balancePair[type] === closeType ? pairIndex : -1;
+        } else if (blockTokens[type] === 2) {
+            // block close token
+            const pairIndex = this.balance[tokenIndex];
+            const openType = this.getTokenType(pairIndex);
+
+            return balancePair[openType] === type ? pairIndex : -1;
+        }
+
+        return -1;
+    }
+    isBalanceEdge(tokenIndex) {
+        return this.balance[this.tokenIndex] < tokenIndex;
+    }
+
     isDelim(code, offset) {
         if (offset) {
             return (
@@ -278,7 +328,7 @@ export class TokenStream {
 
                 default:
                     // fast forward to the end of balanced block for an open block tokens
-                    if (isBlockOpenerToken(this.offsetAndType[cursor] >> TYPE_SHIFT)) {
+                    if (this.isBlockOpenerTokenType(this.offsetAndType[cursor] >> TYPE_SHIFT)) {
                         cursor = balanceEnd;
                     }
             }


### PR DESCRIPTION
This pull request introduces a new feature to handle tokens during parsing, along with corresponding documentation updates and tests. The most important changes include adding a new `onToken` option, updating the parser to support this option, and adding tests to ensure the new functionality works correctly.

I took a cue from the design of `onComment` and so `onToken` receives three arguments:

1. `type` - the string name of the token
2. `value` - the representation of the token in the source text
3. `loc` - the location of the token

Other decisions made:

* `onToken()` is not called for white space or comment tokens. I'm assuming anyone who cares about comments will use `onComment` and that no one really cares about whitespace tokens.


Fixes #205

### New Feature: Token Handling

* [`docs/parsing.md`](diffhunk://#diff-f6518598c49353c6dd23850c3af87f8213a478ec071ba5b8feba4d28570beba2R30): Added documentation for the new `onToken` option, which allows a handler to be called for every non-whitespace, non-comment token in the parsing source. [[1]](diffhunk://#diff-f6518598c49353c6dd23850c3af87f8213a478ec071ba5b8feba4d28570beba2R30) [[2]](diffhunk://#diff-f6518598c49353c6dd23850c3af87f8213a478ec071ba5b8feba4d28570beba2R107-R113)

### Parser Updates

* [`lib/parser/create.js`](diffhunk://#diff-ce97140e9ee81523283d0d32734140c7fb92f3169d57f27ee5d11fa1b1af6d2fL318-R347): Updated the `createParser` function to include the `onToken` option and modified the token processing logic to call the `onToken` handler when appropriate.

### Tests

* [`lib/__tests/parse.js`](diffhunk://#diff-c4e30655c2d8cb0f22ee50b0e16a062fa38a8631331b8acef0c67c2588b17f33R374-R443): Added new test cases to verify the `onToken` functionality, both with and without location information.