### PR TITLE
Implement strict parsing mode

### DIFF
--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -36,12 +36,13 @@ Options (optional):
 - [parseRulePrelude](#parseruleprelude)
 - [parseValue](#parsevalue)
 - [parseCustomProperty](#parsecustomproperty)
+- [strict](#strict)
 
 <!-- /MarkdownTOC -->
 
 ### context
 
-Type: `string`  
+Type: `string`
 Default: `'stylesheet'`
 
 Defines what part of CSS is parsing.
@@ -63,21 +64,21 @@ Contexts:
 
 ### atrule
 
-Type: `string` or `null`  
+Type: `string` or `null`
 Default: `null`
 
 Using for `atrulePrelude` context to apply atrule specific parse rules.
 
 ### positions
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Specify to store locations of node content in original source. Location is storing as `loc` field of nodes. `loc` property is always `null` when this option is `false`. See structure of [`loc`](ast.md#loc) in AST format description.
 
 ### onParseError
 
-Type: `function(error, fallbackNode)` or `null`  
+Type: `function(error, fallbackNode)` or `null`
 Default: `null`
 
 Parsing is tolerant by default, i.e. any text may to be parsed with no an raised exception. However, mistakes in CSS may make it imposible to parse some part, e.g. a selector or declaration. In that case bad content is wrapping into a `Raw` node and `onParseError` is invoking.
@@ -98,42 +99,42 @@ csstree.parse('example { foo; bar: 1! }', {
 
 ### onComment
 
-Type: `function(value, loc)` or `null`  
+Type: `function(value, loc)` or `null`
 Default: `null`
 
 A handler to call for every comment in parsing source. Value is passing without surrounding `/*` and `*/`. [`loc`](ast.md#loc) will be `null` until `positions` option is set to `true`.
 
 ### filename
 
-Type: `string`  
+Type: `string`
 Default: `'<unknown>'`
 
 Filename of source. This value adds to [`loc`](ast.md#loc) as `source` property when `positions` option is `true`. Using for source map generation.
 
 ### offset
 
-Type: `number`  
+Type: `number`
 Default: `0`
 
 Start offset. Useful when parsing a fragment of CSS to store a correct positions for node's [`loc`](ast.md#loc) property.
 
 ### line
 
-Type: `number`  
+Type: `number`
 Default: `1`
 
 Start line number. Useful when parsing fragment of CSS to store correct positions in node's [`loc`](ast.md#loc) property.
 
 ### column
 
-Type: `number`  
+Type: `number`
 Default: `1`
 
 Start column number. Useful when parsing fragment of CSS to store correct positions in node's `loc` property.
 
 ### parseAtrulePrelude
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 Defines to parse an at-rule prelude in details (represents as `AtruleExpresion`, `MediaQueryList` or `SelectorList` if any). Otherwise, represents prelude as `Raw` node.
@@ -179,7 +180,7 @@ csstree.parse('@example 1 2;', {
 
 ### parseRulePrelude
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 Defines to parse a rule prelude in details or left unparsed (represents as `Raw` node).
@@ -233,7 +234,7 @@ csstree.parse('.foo {}', {
 
 ### parseValue
 
-Type: `boolean`  
+Type: `boolean`
 Default: `true`
 
 Defines to parse a declaration value in details (represents as `Value`). Otherwise represents value as `Raw` node.
@@ -274,7 +275,7 @@ csstree.parse('color: #aabbcc', {
 
 ### parseCustomProperty
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Defines to parse a custom property value and a `var()` fallback in details (represents as `Value`). Otherwise represents value as `Raw` node.
@@ -312,3 +313,12 @@ csstree.parse('--custom: #aabbcc', {
 //     }
 // }
 ```
+### strict
+
+Type: `boolean`
+Default: `false`
+
+Enables strict parsing mode, in which more errors are reported through `onParseError()`. These errors are allowed by the CSS specification but are most likely user errors:
+
+- Unclosed comments
+- Unclosed blocks

--- a/lib/__tests/parse.js
+++ b/lib/__tests/parse.js
@@ -463,4 +463,50 @@ describe('parse', () => {
             ]);
         });
     });
+
+    describe('strict', () => {
+
+        const throwOnParseErrorOptions = {
+            onParseError: e => {
+                throw e;
+            }
+        };
+
+        it('strict unclosed block', () => {
+            assert.throws(() => {
+                parse('a {', { strict: true, ...throwOnParseErrorOptions });
+            }, function (e) {
+                assert.strictEqual(e.message, '} expected');
+                assert.strictEqual(e.line, 1);
+                assert.strictEqual(e.column, 4);
+
+                return true;
+            });
+        });
+
+        it('loose unclosed block', () => {
+            const ast = parse('a {', { strict: false });
+            assert.strictEqual(ast.children.size, 1);
+            assert.strictEqual(ast.children.first.type, 'Rule');
+        });
+
+        it('strict unclosed comment', () => {
+            assert.throws(() => {
+                parse('a { } /* foo', { strict: true, ...throwOnParseErrorOptions });
+            }, function (e) {
+                assert.strictEqual(e.message, 'Unclosed comment');
+                assert.strictEqual(e.line, 1);
+                assert.strictEqual(e.column, 7);
+
+                return true;
+            });
+        });
+
+        it('loose unclosed comment', () => {
+            const ast = parse('a { } /* foo', { strict: false });
+            assert.strictEqual(ast.children.size, 1);
+            assert.strictEqual(ast.children.last.type, 'Rule');
+        });
+
+    });
 });

--- a/lib/parser/create.js
+++ b/lib/parser/create.js
@@ -92,6 +92,7 @@ export function createParser(config) {
         parseRulePrelude: true,
         parseValue: true,
         parseCustomProperty: false,
+        strict: false,
 
         readSequence,
 
@@ -310,6 +311,7 @@ export function createParser(config) {
         onParseError = typeof options.onParseError === 'function' ? options.onParseError : NOOP;
         onParseErrorThrow = false;
 
+        parser.strict = Boolean(options.strict);
         parser.parseAtrulePrelude = 'parseAtrulePrelude' in options ? Boolean(options.parseAtrulePrelude) : true;
         parser.parseRulePrelude = 'parseRulePrelude' in options ? Boolean(options.parseRulePrelude) : true;
         parser.parseValue = 'parseValue' in options ? Boolean(options.parseValue) : true;

--- a/lib/syntax/node/Block.js
+++ b/lib/syntax/node/Block.js
@@ -49,10 +49,13 @@ export function parse(isStyleBlock) {
 
     this.eat(LeftCurlyBracket);
 
+    let foundRightCurlyBracket = false;
+
     scan:
     while (!this.eof) {
         switch (this.tokenType) {
             case RightCurlyBracket:
+                foundRightCurlyBracket = true;
                 break scan;
 
             case WhiteSpace:
@@ -73,7 +76,11 @@ export function parse(isStyleBlock) {
         }
     }
 
-    if (!this.eof) {
+    if (this.eof) {
+        if (this.strict && !foundRightCurlyBracket) {
+            this.error('} expected');
+        }
+    } else {
         this.eat(RightCurlyBracket);
     }
 

--- a/lib/syntax/node/Comment.js
+++ b/lib/syntax/node/Comment.js
@@ -19,6 +19,8 @@ export function parse() {
         this.charCodeAt(end - 2) === ASTERISK &&
         this.charCodeAt(end - 1) === SOLIDUS) {
         end -= 2;
+    } else if (this.strict) {
+        this.error('Unclosed comment');
     }
 
     return {

--- a/lib/syntax/node/StyleSheet.js
+++ b/lib/syntax/node/StyleSheet.js
@@ -7,6 +7,8 @@ import {
 } from '../../tokenizer/index.js';
 
 const EXCLAMATIONMARK = 0x0021; // U+0021 EXCLAMATION MARK (!)
+const STAR = 0x002A; // U+002A ASTERISK (*)
+const SOLIDUS = 0x002F; // U+002F SOLIDUS (/)
 
 function consumeRaw() {
     return this.Raw(null, false);
@@ -38,6 +40,12 @@ export function parse() {
                 continue;
 
             case Comment:
+
+                if (this.strict && this.charCodeAt(this.tokenEnd) !== SOLIDUS && this.charCodeAt(this.tokenEnd - 1) !== STAR) {
+                    this.error('Unclosed comment');
+                }
+
+
                 // ignore comments except exclamation comments (i.e. /*! .. */) on top level
                 if (this.charCodeAt(this.tokenStart + 2) !== EXCLAMATIONMARK) {
                     this.next();


### PR DESCRIPTION
This pull request introduces a new feature for strict parsing mode in the CSS parsing library. The strict mode aims to enhance error reporting for common user errors such as unclosed comments and blocks. The changes include updates to the documentation, tests, and the parser implementation to support this new mode.

fixes #301

### Documentation updates:
* Added a new section for the `strict` option in `docs/parsing.md` to explain its purpose and default value. [[1]](diffhunk://#diff-f6518598c49353c6dd23850c3af87f8213a478ec071ba5b8feba4d28570beba2R39) [[2]](diffhunk://#diff-f6518598c49353c6dd23850c3af87f8213a478ec071ba5b8feba4d28570beba2R316-R324)

### Test updates:
* Added new tests in `lib/__tests/parse.js` to verify the behavior of strict mode for unclosed blocks and comments.

### Parser implementation updates:
* Updated `lib/parser/create.js` to include the `strict` option and ensure it is properly handled during parser creation. [[1]](diffhunk://#diff-ce97140e9ee81523283d0d32734140c7fb92f3169d57f27ee5d11fa1b1af6d2fR95) [[2]](diffhunk://#diff-ce97140e9ee81523283d0d32734140c7fb92f3169d57f27ee5d11fa1b1af6d2fR314)
* Modified `lib/syntax/node/Block.js` to check for unclosed blocks when strict mode is enabled. [[1]](diffhunk://#diff-ffb79eed874e2064a04053794a28808dd336ec60ee7fe40043e7058d17dd452aR52-R58) [[2]](diffhunk://#diff-ffb79eed874e2064a04053794a28808dd336ec60ee7fe40043e7058d17dd452aL76-R83)
* Updated `lib/syntax/node/Comment.js` to report unclosed comments in strict mode.
* Enhanced `lib/syntax/node/StyleSheet.js` to detect unclosed comments in strict mode. [[1]](diffhunk://#diff-fb0cf92802622776c4a0a1900b06dbeaa48495dcf930a4014a149ff86eec996eR10-R11) [[2]](diffhunk://#diff-fb0cf92802622776c4a0a1900b06dbeaa48495dcf930a4014a149ff86eec996eR43-R48)