### PR TITLE
Update mdn-data to v2.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added support for [boolean expression multiplier](https://drafts.csswg.org/css-values-5/#boolean) in syntax definition, i.e. `<boolean[ test ]>` (#304)
 - Fixed syntax definition parser to allow a token to be followed by a multiplier (#303)
+- Bumped `mdn/data` to 2.12.2
 
 ## 3.0.1 (November 1, 2024)
 

--- a/data/patch.json
+++ b/data/patch.json
@@ -433,13 +433,6 @@
             ],
             "syntax": "<number-one-or-greater>"
         },
-        "stroke-opacity": {
-            "comment": "added SVG property",
-            "references": [
-                "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
-            ],
-            "syntax": "<'opacity'>"
-        },
         "stroke-width": {
             "comment": "added SVG property",
             "references": [
@@ -709,9 +702,6 @@
         },
         "color-function": {
             "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
-        },
-        "system-color": {
-            "syntax": "AccentColor | AccentColorText | ActiveText | ButtonBorder | ButtonFace | ButtonText | Canvas | CanvasText | Field | FieldText | GrayText | Highlight | HighlightText | LinkText | Mark | MarkText | SelectedItem | SelectedItemText | VisitedText"
         },
         "device-cmyk()": {
             "syntax": "<legacy-device-cmyk-syntax> | <modern-device-cmyk-syntax>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.1",
+        "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
       },
       "devDependencies": {
@@ -1583,10 +1583,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.1.tgz",
-      "integrity": "sha512-rsfnCbOHjqrhWxwt5/wtSLzpoKTzW7OXdT5lLOIH1OTYhWu9rRJveGq0sKvDZODABH7RX+uoR+DYcpFnq4Tf6Q==",
-      "license": "CC0-1.0"
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3327,9 +3326,9 @@
       }
     },
     "mdn-data": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.1.tgz",
-      "integrity": "sha512-rsfnCbOHjqrhWxwt5/wtSLzpoKTzW7OXdT5lLOIH1OTYhWu9rRJveGq0sKvDZODABH7RX+uoR+DYcpFnq4Tf6Q=="
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "prepublishOnly": "npm run lint-and-test && npm run build-and-test"
   },
   "dependencies": {
-    "mdn-data": "2.12.1",
+    "mdn-data": "2.12.2",
     "source-map-js": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Even though `mdn-data` was recently updated, v2.12.2 contains the critical fixes (https://github.com/mdn/data/pull/771). Please merge as soon as possible.