### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   ],
   "type": "module",
   "module": "./lib/index.js",
+  "sideEffects": false,
   "main": "./cjs/index.cjs",
   "exports": {
     ".": {


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code with treeshake. Good with esm, modules, named imports.