### PR TITLE
Fix patched syntax for unicode-range

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -10,7 +10,7 @@
             "descriptors": {
                 "unicode-range": {
                     "comment": "replaces <unicode-range>, an old production name",
-                    "syntax": "<urange>#"
+                    "syntax": "<unicode-range-token>#"
                 }
             }
         },
@@ -447,10 +447,6 @@
         "unicode-bidi": {
             "comment": "added prefixed keywords https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi",
             "syntax": "| -moz-isolate | -moz-isolate-override | -moz-plaintext | -webkit-isolate | -webkit-isolate-override | -webkit-plaintext"
-        },
-        "unicode-range": {
-            "comment": "added missed property https://developer.mozilla.org/en-US/docs/Web/CSS/%40font-face/unicode-range",
-            "syntax": "<urange>#"
         },
         "voice-balance": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",


### PR DESCRIPTION
see https://github.com/mdn/data/pull/833

also note that `unicode-range` cann't be used as a property, but a descriptor of @font-face