### PR TITLE
Remove wrong container-type property patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -218,10 +218,6 @@
             "comment": "added old IE property https://msdn.microsoft.com/en-us/library/ms530723(v=vs.85).aspx",
             "syntax": "<url>+"
         },
-        "container-type": {
-            "comment": "https://www.w3.org/TR/css-contain-3/#propdef-container-type",
-            "syntax": "normal || [ size | inline-size ]"
-        },
         "cue": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<'cue-before'> <'cue-after'>?"


### PR DESCRIPTION
the syntax for this property should be `normal | size | inline-size`, the patch is not correct, and the data in https://github.com/mdn/data/blob/v2.12.2/css/properties.json#L4509-L4524 is correct, so it is fine to remove this patch

https://developer.mozilla.org/en-US/docs/Web/CSS/container-type
https://www.w3.org/TR/css-conditional-5/#propdef-container-type