### PR TITLE
feat: Add configurable lexer iterations

### DIFF
--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -72,7 +72,7 @@ function buildMatchResult(matched, error, iterations) {
     };
 }
 
-function matchSyntax(lexer, syntax, value, useCssWideKeywords) {
+function matchSyntax(lexer, syntax, value, useCssWideKeywords, options) {
     const tokens = prepareTokens(value, lexer.syntax);
     let result;
 
@@ -81,11 +81,11 @@ function matchSyntax(lexer, syntax, value, useCssWideKeywords) {
     }
 
     if (useCssWideKeywords) {
-        result = matchAsTree(tokens, lexer.cssWideKeywordsSyntax, lexer);
+        result = matchAsTree(tokens, lexer.cssWideKeywordsSyntax, lexer, options);
     }
 
     if (!useCssWideKeywords || !result.match) {
-        result = matchAsTree(tokens, syntax.match, lexer);
+        result = matchAsTree(tokens, syntax.match, lexer, options);
         if (!result.match) {
             return buildMatchResult(
                 null,
@@ -99,7 +99,7 @@ function matchSyntax(lexer, syntax, value, useCssWideKeywords) {
 }
 
 export class Lexer {
-    constructor(config, syntax, structure) {
+    constructor(config, syntax, structure, options) {
         this.cssWideKeywords = cssWideKeywords;
         this.syntax = syntax;
         this.generic = false;
@@ -108,6 +108,7 @@ export class Lexer {
         this.properties = Object.create(null);
         this.types = Object.create(null);
         this.structure = structure || getStructureFromConfig(config);
+        this.options = options || {};
 
         if (config) {
             if (config.cssWideKeywords) {
@@ -291,7 +292,7 @@ export class Lexer {
         }
 
         if (atrule.prelude && !prelude) {
-            if (!matchSyntax(this, atrule.prelude, '', false).matched) {
+            if (!matchSyntax(this, atrule.prelude, '', false, this.options).matched) {
                 return new SyntaxError('At-rule `@' + atruleName + '` should contain a prelude');
             }
         }
@@ -334,7 +335,7 @@ export class Lexer {
             return buildMatchResult(null, null);
         }
 
-        return matchSyntax(this, atrule.prelude, prelude || '', false);
+        return matchSyntax(this, atrule.prelude, prelude || '', false, this.options);
     }
     matchAtruleDescriptor(atruleName, descriptorName, value) {
         const error = this.checkAtruleDescriptorName(atruleName, descriptorName);
@@ -346,7 +347,7 @@ export class Lexer {
         const atrule = this.getAtrule(atruleName);
         const descriptor = names.keyword(descriptorName);
 
-        return matchSyntax(this, atrule.descriptors[descriptor.name] || atrule.descriptors[descriptor.basename], value, false);
+        return matchSyntax(this, atrule.descriptors[descriptor.name] || atrule.descriptors[descriptor.basename], value, false, this.options);
     }
     matchDeclaration(node) {
         if (node.type !== 'Declaration') {
@@ -367,7 +368,7 @@ export class Lexer {
             return buildMatchResult(null, error);
         }
 
-        return matchSyntax(this, this.getProperty(propertyName), value, true);
+        return matchSyntax(this, this.getProperty(propertyName), value, true, this.options);
     }
     matchType(typeName, value) {
         const typeSyntax = this.getType(typeName);
@@ -376,7 +377,7 @@ export class Lexer {
             return buildMatchResult(null, new SyntaxReferenceError('Unknown type', typeName));
         }
 
-        return matchSyntax(this, typeSyntax, value, false);
+        return matchSyntax(this, typeSyntax, value, false, this.options);
     }
     match(syntax, value) {
         if (typeof syntax !== 'string' && (!syntax || !syntax.type)) {
@@ -387,7 +388,7 @@ export class Lexer {
             syntax = this.createDescriptor(syntax, 'Type', 'anonymous');
         }
 
-        return matchSyntax(this, syntax, value, false);
+        return matchSyntax(this, syntax, value, false, this.options);
     }
 
     findValueFragments(propertyName, value, type, name) {

--- a/lib/lexer/match.js
+++ b/lib/lexer/match.js
@@ -89,7 +89,7 @@ function isCommaContextEnd(token) {
     );
 }
 
-function internalMatch(tokens, state, syntaxes) {
+function internalMatch(tokens, state, syntaxes, { maxIterations = ITERATION_LIMIT } = {}) {
     function moveToNextToken() {
         do {
             tokenIndex++;
@@ -197,7 +197,7 @@ function internalMatch(tokens, state, syntaxes) {
 
     moveToNextToken();
 
-    while (exitReason === null && ++iterationCount < ITERATION_LIMIT) {
+    while (exitReason === null && ++iterationCount < maxIterations) {
         // function mapList(list, fn) {
         //     const result = [];
         //     while (list) {
@@ -525,7 +525,7 @@ function internalMatch(tokens, state, syntaxes) {
 
     switch (exitReason) {
         case null:
-            console.warn('[csstree-match] BREAK after ' + ITERATION_LIMIT + ' iterations');
+            console.warn('[csstree-match] BREAK after ' + maxIterations + ' iterations');
             exitReason = EXIT_REASON_ITERATION_LIMIT;
             matchStack = null;
             break;
@@ -549,8 +549,8 @@ function internalMatch(tokens, state, syntaxes) {
     };
 }
 
-export function matchAsList(tokens, matchGraph, syntaxes) {
-    const matchResult = internalMatch(tokens, matchGraph, syntaxes || {});
+export function matchAsList(tokens, matchGraph, syntaxes, options) {
+    const matchResult = internalMatch(tokens, matchGraph, syntaxes || {}, options);
 
     if (matchResult.match !== null) {
         let item = reverseList(matchResult.match).prev;
@@ -582,8 +582,8 @@ export function matchAsList(tokens, matchGraph, syntaxes) {
     return matchResult;
 }
 
-export function matchAsTree(tokens, matchGraph, syntaxes) {
-    const matchResult = internalMatch(tokens, matchGraph, syntaxes || {});
+export function matchAsTree(tokens, matchGraph, syntaxes, options) {
+    const matchResult = internalMatch(tokens, matchGraph, syntaxes || {}, options);
 
     if (matchResult.match === null) {
         return matchResult;

--- a/lib/syntax/create.js
+++ b/lib/syntax/create.js
@@ -6,7 +6,7 @@ import { createWalker } from '../walker/create.js';
 import { Lexer } from '../lexer/Lexer.js';
 import mix from './config/mix.js';
 
-function createSyntax(config) {
+function createSyntax(config, options) {
     const parse = createParser(config);
     const walk = createWalker(config);
     const generate = createGenerator(config);
@@ -14,7 +14,7 @@ function createSyntax(config) {
 
     const syntax = {
         lexer: null,
-        createLexer: config => new Lexer(config, syntax, syntax.lexer.structure),
+        createLexer: config => new Lexer(config, syntax, syntax.lexer.structure, options),
 
         tokenize,
         parse,
@@ -28,13 +28,14 @@ function createSyntax(config) {
         fromPlainObject,
         toPlainObject,
 
-        fork(extension) {
+        fork(extension, options) {
             const base = mix({}, config); // copy of config
 
             return createSyntax(
                 typeof extension === 'function'
                     ? extension(base) // TODO: remove Object.assign as second parameter
-                    : mix(base, extension)
+                    : mix(base, extension),
+                options
             );
         }
     };
@@ -47,9 +48,9 @@ function createSyntax(config) {
         atrules: config.atrules,
         properties: config.properties,
         node: config.node
-    }, syntax);
+    }, syntax, undefined, options);
 
     return syntax;
 };
 
-export default config => createSyntax(mix({}, config));
+export default (config, options) => createSyntax(mix({}, config), options);


### PR DESCRIPTION
This pull request introduces changes to the `Lexer` class and related functions to add support for an `options` parameter. The most important changes include modifying several functions to accept the new parameter and updating the `Lexer` class constructor to initialize with `options`.

I couldn't quite figure out where tests for this functionality should go as there doesn't appear to be any existing tests that exercise the iteration limit. If you let me know where to add such tests, I'd be happy to.

Fixes #294 

Enhancements to `Lexer` class:

* [`lib/lexer/Lexer.js`](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L102-R102): Updated the `Lexer` class constructor to accept and initialize an `options` parameter. [[1]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L102-R102) [[2]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242R111)

Function parameter updates:

* [`lib/lexer/Lexer.js`](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L75-R75): Modified the `matchSyntax` function to accept an `options` parameter and updated its calls throughout the `Lexer` class. [[1]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L75-R75) [[2]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L84-R88) [[3]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L294-R295) [[4]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L337-R338) [[5]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L349-R350) [[6]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L370-R371) [[7]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L379-R380) [[8]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L390-R391)
* [`lib/lexer/match.js`](diffhunk://#diff-fd53d28ed67fd15624fa55d1bae3bf14039912d46b71d72fb1470236825d28a0L552-R553): Updated `matchAsList` and `matchAsTree` functions to accept an `options` parameter and pass it to `internalMatch`. [[1]](diffhunk://#diff-fd53d28ed67fd15624fa55d1bae3bf14039912d46b71d72fb1470236825d28a0L552-R553) [[2]](diffhunk://#diff-fd53d28ed67fd15624fa55d1bae3bf14039912d46b71d72fb1470236825d28a0L585-R586)

Iteration limit customization:

* [`lib/lexer/match.js`](diffhunk://#diff-fd53d28ed67fd15624fa55d1bae3bf14039912d46b71d72fb1470236825d28a0L92-R92): Modified `internalMatch` to accept an `options` parameter with a customizable `maxIterations` limit. [[1]](diffhunk://#diff-fd53d28ed67fd15624fa55d1bae3bf14039912d46b71d72fb1470236825d28a0L92-R92) [[2]](diffhunk://#diff-fd53d28ed67fd15624fa55d1bae3bf14039912d46b71d72fb1470236825d28a0L200-R200) [[3]](diffhunk://#diff-fd53d28ed67fd15624fa55d1bae3bf14039912d46b71d72fb1470236825d28a0L528-R528)

Syntax creation updates:

* [`lib/syntax/create.js`](diffhunk://#diff-bbb968dbb2bbc0234bdc440328542d3ac999fcd3ee05683fcda6b37c029be232L9-R17): Updated `createSyntax` and related functions to accept and propagate an `options` parameter. [[1]](diffhunk://#diff-bbb968dbb2bbc0234bdc440328542d3ac999fcd3ee05683fcda6b37c029be232L9-R17) [[2]](diffhunk://#diff-bbb968dbb2bbc0234bdc440328542d3ac999fcd3ee05683fcda6b37c029be232L31-R38) [[3]](diffhunk://#diff-bbb968dbb2bbc0234bdc440328542d3ac999fcd3ee05683fcda6b37c029be232L50-R56)

