### PR TITLE
Add patch for `overflow-x` and `overflow-y`

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -145,7 +145,9 @@
         },
         "-webkit-appearance": {
             "comment": "webkit specific keywords",
-            "references": ["http://css-infos.net/property/-webkit-appearance"],
+            "references": [
+                "http://css-infos.net/property/-webkit-appearance"
+            ],
             "syntax": "none | button | button-bevel | caps-lock-indicator | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbargripper-horizontal | scrollbargripper-vertical | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button"
         },
         "-webkit-background-clip": {
@@ -200,7 +202,9 @@
         },
         "background-clip": {
             "comment": "used <bg-clip> from CSS Backgrounds and Borders 4 since it adds new values",
-            "references": ["https://github.com/csstree/csstree/issues/190"],
+            "references": [
+                "https://github.com/csstree/csstree/issues/190"
+            ],
             "syntax": "<bg-clip>#"
         },
         "baseline-shift": {
@@ -232,7 +236,9 @@
         },
         "cursor": {
             "comment": "added legacy keywords: hand, -webkit-grab. -webkit-grabbing, -webkit-zoom-in, -webkit-zoom-out, -moz-grab, -moz-grabbing, -moz-zoom-in, -moz-zoom-out",
-            "references": ["https://www.sitepoint.com/css3-cursor-styles/"],
+            "references": [
+                "https://www.sitepoint.com/css3-cursor-styles/"
+            ],
             "syntax": "[ [ <url> [ <x> <y> ]? , ]* [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing | hand | -webkit-grab | -webkit-grabbing | -webkit-zoom-in | -webkit-zoom-out | -moz-grab | -moz-grabbing | -moz-zoom-in | -moz-zoom-out ] ]"
         },
         "display": {
@@ -808,7 +814,9 @@
         },
         "svg-length": {
             "comment": "All coordinates and lengths in SVG can be specified with or without a unit identifier",
-            "references": ["https://www.w3.org/TR/SVG11/coords.html#Units"],
+            "references": [
+                "https://www.w3.org/TR/SVG11/coords.html#Units"
+            ],
             "syntax": "<percentage> | <length> | <number>"
         },
         "svg-writing-mode": {

--- a/data/patch.json
+++ b/data/patch.json
@@ -145,9 +145,7 @@
         },
         "-webkit-appearance": {
             "comment": "webkit specific keywords",
-            "references": [
-                "http://css-infos.net/property/-webkit-appearance"
-            ],
+            "references": ["http://css-infos.net/property/-webkit-appearance"],
             "syntax": "none | button | button-bevel | caps-lock-indicator | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbargripper-horizontal | scrollbargripper-vertical | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button"
         },
         "-webkit-background-clip": {
@@ -202,9 +200,7 @@
         },
         "background-clip": {
             "comment": "used <bg-clip> from CSS Backgrounds and Borders 4 since it adds new values",
-            "references": [
-                "https://github.com/csstree/csstree/issues/190"
-            ],
+            "references": ["https://github.com/csstree/csstree/issues/190"],
             "syntax": "<bg-clip>#"
         },
         "baseline-shift": {
@@ -236,9 +232,7 @@
         },
         "cursor": {
             "comment": "added legacy keywords: hand, -webkit-grab. -webkit-grabbing, -webkit-zoom-in, -webkit-zoom-out, -moz-grab, -moz-grabbing, -moz-zoom-in, -moz-zoom-out",
-            "references": [
-                "https://www.sitepoint.com/css3-cursor-styles/"
-            ],
+            "references": ["https://www.sitepoint.com/css3-cursor-styles/"],
             "syntax": "[ [ <url> [ <x> <y> ]? , ]* [ auto | default | none | context-menu | help | pointer | progress | wait | cell | crosshair | text | vertical-text | alias | copy | move | no-drop | not-allowed | e-resize | n-resize | ne-resize | nw-resize | s-resize | se-resize | sw-resize | w-resize | ew-resize | ns-resize | nesw-resize | nwse-resize | col-resize | row-resize | all-scroll | zoom-in | zoom-out | grab | grabbing | hand | -webkit-grab | -webkit-grabbing | -webkit-zoom-in | -webkit-zoom-out | -moz-grab | -moz-grabbing | -moz-zoom-in | -moz-zoom-out ] ]"
         },
         "display": {
@@ -346,6 +340,14 @@
         },
         "overflow": {
             "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow",
+            "syntax": "| <-non-standard-overflow>"
+        },
+        "overflow-x": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x",
+            "syntax": "| <-non-standard-overflow>"
+        },
+        "overflow-y": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y",
             "syntax": "| <-non-standard-overflow>"
         },
         "pause": {
@@ -806,9 +808,7 @@
         },
         "svg-length": {
             "comment": "All coordinates and lengths in SVG can be specified with or without a unit identifier",
-            "references": [
-                "https://www.w3.org/TR/SVG11/coords.html#Units"
-            ],
+            "references": ["https://www.w3.org/TR/SVG11/coords.html#Units"],
             "syntax": "<percentage> | <length> | <number>"
         },
         "svg-writing-mode": {


### PR DESCRIPTION
Added support for `<-nonstandard-overflow>` similar to `overflow`.

Related: https://github.com/stylelint/stylelint/issues/8339