### PR TITLE
feat: Custom variable replacement for validation

### DIFF
--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -89,7 +89,7 @@ describe('Lexer#matchProperty()', () => {
 
         it('should be matched to var() when provided with variable values', () => {
             const match = lexer.matchProperty('color', parse('var(--foo)', { context: 'value' }), {
-                variables: {
+                vars: {
                     '--foo': 'red'
                 }
             });

--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -79,6 +79,26 @@ describe('Lexer#matchProperty()', () => {
         });
     });
 
+    describe('var()', () => {
+        it('should not be matched to var()', () => {
+            const match = lexer.matchProperty('color', parse('var(--foo)', { context: 'value' }));
+
+            assert.strictEqual(match.matched, null);
+            assert.strictEqual(match.error.message, 'Matching for a tree with var() is not supported');
+        });
+
+        it('should be matched to var() when provided with variable values', () => {
+            const match = lexer.matchProperty('color', parse('var(--foo)', { context: 'value' }), {
+                variables: {
+                    '--foo': 'red'
+                }
+            });
+
+            assert(match.matched);
+            assert.strictEqual(match.error, null);
+        });
+    });
+
     it('custom property', () => {
         const match = lexer.matchProperty('--foo', lazy.bar);
 

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -72,10 +72,10 @@ function buildMatchResult(matched, error, iterations) {
     };
 }
 
-function replaceVarTokens(tokens, lexer, syntax, options = { variables: {} }) {
+function replaceVarTokens(tokens, lexer, syntax, options = { vars: {} }) {
 
     const result = [];
-    const vars = options.variables;
+    const vars = options.vars;
 
     for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i];

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -102,13 +102,13 @@ function replaceVarTokens(tokens, lexer, syntax, options = { variables: {} }) {
 
 }
 
-function matchSyntax(lexer, syntax, value, useCssWideKeywords, vars) {
+function matchSyntax(lexer, syntax, value, useCssWideKeywords, options) {
     let tokens = prepareTokens(value, lexer.syntax);
     let result;
 
     if (valueHasVar(tokens)) {
 
-        let replacementTokens = replaceVarTokens(tokens, lexer, syntax, vars);
+        let replacementTokens = replaceVarTokens(tokens, lexer, syntax, options);
 
         if (!replacementTokens) {
             return buildMatchResult(null, new Error('Matching for a tree with var() is not supported'));
@@ -385,14 +385,14 @@ export class Lexer {
 
         return matchSyntax(this, atrule.descriptors[descriptor.name] || atrule.descriptors[descriptor.basename], value, false);
     }
-    matchDeclaration(node, vars) {
+    matchDeclaration(node, options) {
         if (node.type !== 'Declaration') {
             return buildMatchResult(null, new Error('Not a Declaration node'));
         }
 
-        return this.matchProperty(node.property, node.value, vars);
+        return this.matchProperty(node.property, node.value, options);
     }
-    matchProperty(propertyName, value, vars) {
+    matchProperty(propertyName, value, options) {
         // don't match syntax for a custom property at the moment
         if (names.property(propertyName).custom) {
             return buildMatchResult(null, new Error('Lexer matching doesn\'t applicable for custom properties'));
@@ -404,7 +404,7 @@ export class Lexer {
             return buildMatchResult(null, error);
         }
 
-        return matchSyntax(this, this.getProperty(propertyName), value, true, vars);
+        return matchSyntax(this, this.getProperty(propertyName), value, true, options);
     }
     matchType(typeName, value) {
         const typeSyntax = this.getType(typeName);

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -80,7 +80,7 @@ function replaceVarTokens(tokens, lexer, syntax, options = { vars: {} }) {
     for (let i = 0; i < tokens.length; i++) {
         const token = tokens[i];
 
-        if (token.value === 'var(') {
+        if (token.value.toLowerCase() === 'var(') {
 
             i += 1;
             const idToken = tokens[i++];

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -72,12 +72,49 @@ function buildMatchResult(matched, error, iterations) {
     };
 }
 
-function matchSyntax(lexer, syntax, value, useCssWideKeywords) {
-    const tokens = prepareTokens(value, lexer.syntax);
+function replaceVarTokens(tokens, lexer, syntax, options = { variables: {} }) {
+
+    const result = [];
+    const vars = options.variables;
+
+    for (let i = 0; i < tokens.length; i++) {
+        const token = tokens[i];
+
+        if (token.value === 'var(') {
+
+            i += 1;
+            const idToken = tokens[i++];
+            const replacementValue = vars[idToken.value];
+
+            // don't attempt replacement if the value is not defined
+            if (!replacementValue) {
+                return null;
+            }
+
+            const replacementTokens = prepareTokens(replacementValue, lexer, syntax);
+            result.push(...replacementTokens);
+        } else {
+            result.push(token);
+        }
+    }
+
+    return result;
+
+}
+
+function matchSyntax(lexer, syntax, value, useCssWideKeywords, vars) {
+    let tokens = prepareTokens(value, lexer.syntax);
     let result;
 
     if (valueHasVar(tokens)) {
-        return buildMatchResult(null, new Error('Matching for a tree with var() is not supported'));
+
+        let replacementTokens = replaceVarTokens(tokens, lexer, syntax, vars);
+
+        if (!replacementTokens) {
+            return buildMatchResult(null, new Error('Matching for a tree with var() is not supported'));
+        }
+
+        tokens = replacementTokens;
     }
 
     if (useCssWideKeywords) {
@@ -348,14 +385,14 @@ export class Lexer {
 
         return matchSyntax(this, atrule.descriptors[descriptor.name] || atrule.descriptors[descriptor.basename], value, false);
     }
-    matchDeclaration(node) {
+    matchDeclaration(node, vars) {
         if (node.type !== 'Declaration') {
             return buildMatchResult(null, new Error('Not a Declaration node'));
         }
 
-        return this.matchProperty(node.property, node.value);
+        return this.matchProperty(node.property, node.value, vars);
     }
-    matchProperty(propertyName, value) {
+    matchProperty(propertyName, value, vars) {
         // don't match syntax for a custom property at the moment
         if (names.property(propertyName).custom) {
             return buildMatchResult(null, new Error('Lexer matching doesn\'t applicable for custom properties'));
@@ -367,7 +404,7 @@ export class Lexer {
             return buildMatchResult(null, error);
         }
 
-        return matchSyntax(this, this.getProperty(propertyName), value, true);
+        return matchSyntax(this, this.getProperty(propertyName), value, true, vars);
     }
     matchType(typeName, value) {
         const typeSyntax = this.getType(typeName);


### PR DESCRIPTION
This change gives us the ability to pass in substitute values for variables when validating a property. The idea is that ESLint could keep track of the last value for any given custom property and pass that into `lexer.matchProperty()` so that we can actually validate property values containing `var()` (right now CSSTree just throws an error, which we swallow in the ESLint rule).

Ported from https://github.com/csstree/csstree/pull/321

This pull request introduces changes to the `Lexer` class to support the handling of CSS variables (`var()`) during property matching. The most important changes include adding support for variable replacement in the `Lexer` class, updating the `matchProperty` and `matchDeclaration` methods to accept options, and adding new tests to verify the functionality.

Support for CSS variables (`var()`) in property matching:

* [`lib/lexer/Lexer.js`](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L75-R119): Added the `replaceVarTokens` function to handle the replacement of `var()` tokens with their corresponding values from the provided options. Updated the `matchSyntax`, `matchProperty`, and `matchDeclaration` methods to accept an `options` parameter for variable values. [[1]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L75-R119) [[2]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L351-R395) [[3]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L370-R407)

Testing enhancements:

* [`lib/__tests/lexer-match-property.js`](diffhunk://#diff-02ffb908de7190c5ace89f8cbe8ab28a8bec6b9f42f1aac2f1e33da4d8d34b06R82-R101): Added new test cases in the `describe('var()', () => {` block to verify that `var()` is not matched without provided variable values and that it is correctly matched when variable values are provided.