### PR TITLE
fix: Update CSS syntax

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -63,10 +63,6 @@
         }
     },
     "properties": {
-        "-moz-background-clip": {
-            "comment": "deprecated syntax in old Firefox, https://developer.mozilla.org/en/docs/Web/CSS/background-clip",
-            "syntax": "padding | border"
-        },
         "-moz-border-radius-bottomleft": {
             "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius",
             "syntax": "<'border-bottom-left-radius'>"
@@ -149,10 +145,6 @@
                 "http://css-infos.net/property/-webkit-appearance"
             ],
             "syntax": "none | button | button-bevel | caps-lock-indicator | caret | checkbox | default-button | inner-spin-button | listbox | listitem | media-controls-background | media-controls-fullscreen-background | media-current-time-display | media-enter-fullscreen-button | media-exit-fullscreen-button | media-fullscreen-button | media-mute-button | media-overlay-play-button | media-play-button | media-seek-back-button | media-seek-forward-button | media-slider | media-sliderthumb | media-time-remaining-display | media-toggle-closed-captions-button | media-volume-slider | media-volume-slider-container | media-volume-sliderthumb | menulist | menulist-button | menulist-text | menulist-textfield | meter | progress-bar | progress-bar-value | push-button | radio | scrollbarbutton-down | scrollbarbutton-left | scrollbarbutton-right | scrollbarbutton-up | scrollbargripper-horizontal | scrollbargripper-vertical | scrollbarthumb-horizontal | scrollbarthumb-vertical | scrollbartrack-horizontal | scrollbartrack-vertical | searchfield | searchfield-cancel-button | searchfield-decoration | searchfield-results-button | searchfield-results-decoration | slider-horizontal | slider-vertical | sliderthumb-horizontal | sliderthumb-vertical | square-button | textarea | textfield | -apple-pay-button"
-        },
-        "-webkit-background-clip": {
-            "comment": "https://developer.mozilla.org/en/docs/Web/CSS/background-clip",
-            "syntax": "[ <box> | border | padding | content | text ]#"
         },
         "-webkit-column-break-after": {
             "comment": "added, http://help.dottoro.com/lcrthhhv.php",
@@ -591,10 +583,6 @@
         "attr-fallback": {
             "syntax": "<any-value>"
         },
-        "bg-clip": {
-            "comment": "missed, https://drafts.csswg.org/css-backgrounds-4/#typedef-bg-clip",
-            "syntax": "<box> | border | text"
-        },
         "bottom": {
             "comment": "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",
             "syntax": "<length> | auto"
@@ -653,6 +641,10 @@
         "gradient": {
             "comment": "added legacy syntaxes support",
             "syntax": "| <-legacy-gradient>"
+        },
+        "intrinsic-size-keyword": {
+            "comment": "Missing from mdn-data. 4.3. Intrinsic Size Keywords https://www.w3.org/TR/css-sizing-4/#intrinsic-size-keywords",
+            "syntax": "min-content | max-content | fit-content"
         },
         "left": {
             "comment": "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",

--- a/data/patch.json
+++ b/data/patch.json
@@ -200,13 +200,6 @@
             ],
             "syntax": "auto | baseline | before-edge | text-before-edge | middle | central | after-edge | text-after-edge | ideographic | alphabetic | hanging | mathematical"
         },
-        "background-clip": {
-            "comment": "used <bg-clip> from CSS Backgrounds and Borders 4 since it adds new values",
-            "references": [
-                "https://github.com/csstree/csstree/issues/190"
-            ],
-            "syntax": "<bg-clip>#"
-        },
         "baseline-shift": {
             "comment": "added SVG property",
             "references": [
@@ -263,13 +256,6 @@
                 "https://www.w3.org/TR/SVG/painting.html#ImageRenderingProperty"
             ],
             "syntax": "| optimizeSpeed | optimizeQuality | <-non-standard-image-rendering>"
-        },
-        "fill": {
-            "comment": "added SVG property",
-            "references": [
-                "https://www.w3.org/TR/SVG/painting.html#FillProperty"
-            ],
-            "syntax": "<paint>"
         },
         "fill-opacity": {
             "comment": "added SVG property",
@@ -348,6 +334,14 @@
             "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow",
             "syntax": "| <-non-standard-overflow>"
         },
+        "overflow-x": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x",
+            "syntax": "| <-non-standard-overflow>"
+        },
+        "overflow-y": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y",
+            "syntax": "| <-non-standard-overflow>"
+        },
         "pause": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<'pause-before'> <'pause-after'>?"
@@ -359,6 +353,10 @@
         "pause-before": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<time> | none | x-weak | weak | medium | strong | x-strong"
+        },
+        "position-try-options": {
+            "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/position-try-fallbacks",
+            "syntax": "<'position-try-fallbacks'>"
         },
         "rest": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
@@ -379,13 +377,6 @@
             ],
             "syntax": "[ <'scroll-timeline-name'> || <'scroll-timeline-axis'> ]#"
         },
-        "scroll-timeline-name": {
-            "comment": "fix according to spec",
-            "references": [
-                "https://w3c.github.io/csswg-drafts/scroll-animations/#propdef-scroll-timeline-name"
-            ],
-            "syntax": "[ none | <dashed-ident> ]#"
-        },
         "src": {
             "comment": "added @font-face's src property https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src",
             "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#"
@@ -393,17 +384,6 @@
         "speak": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "auto | never | always"
-        },
-        "speak-as": {
-            "comment": "https://www.w3.org/TR/css3-speech/#property-index",
-            "syntax": "normal | spell-out || digits || [ literal-punctuation | no-punctuation ]"
-        },
-        "stroke": {
-            "comment": "added SVG property",
-            "references": [
-                "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
-            ],
-            "syntax": "<paint>"
         },
         "stroke-dasharray": {
             "comment": "added SVG property; a list of comma and/or white space separated <length>s and <percentage>s",
@@ -439,10 +419,6 @@
                 "https://www.w3.org/TR/SVG/painting.html#StrokeProperties"
             ],
             "syntax": "<svg-length>"
-        },
-        "text-wrap": {
-            "comment": "broken in mdn/data",
-            "syntax": "<'text-wrap-mode'> || <'text-wrap-style'>"
         },
         "unicode-bidi": {
             "comment": "added prefixed keywords https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi",
@@ -491,13 +467,6 @@
         "white-space-trim": {
             "syntax": "none | discard-before || discard-after || discard-inner",
             "comment": "missed, https://www.w3.org/TR/css-text-4/#white-space-trim"
-        },
-        "word-break": {
-            "syntax": "normal | break-all | keep-all | break-word | auto-phrase",
-            "comment": "added in Chrome/Edge 119, not covered by a spec currently (2024-09-02)",
-            "references": [
-                "https://developer.mozilla.org/en-US/docs/Web/CSS/word-break"
-            ]
         }
     },
     "types": {
@@ -616,10 +585,6 @@
             "comment": "https://www.w3.org/TR/css3-speech/#voice-family",
             "syntax": "child | young | old"
         },
-        "anchor-name": {
-            "comment": "missed in mdn/data",
-            "syntax": "<dashed-ident>"
-        },
         "attr-name": {
             "syntax": "<wq-name>"
         },
@@ -697,12 +662,6 @@
             "comment": "css-color-5, added non standard color names",
             "syntax": "<color-base> | currentColor | <system-color> | <device-cmyk()>  | <light-dark()> | <-non-standard-color>"
         },
-        "color-base": {
-            "syntax": "<hex-color> | <color-function> | <named-color> | <color-mix()> | transparent"
-        },
-        "color-function": {
-            "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
-        },
         "device-cmyk()": {
             "syntax": "<legacy-device-cmyk-syntax> | <modern-device-cmyk-syntax>"
         },
@@ -718,22 +677,12 @@
         "color-mix()": {
             "syntax": "color-mix( <color-interpolation-method> , [ <color> && <percentage [0,100]>? ]#{2} )"
         },
-        "color-interpolation-method": {
-            "syntax": "in [ <rectangular-color-space> | <polar-color-space> <hue-interpolation-method>? | <custom-color-space> ]"
-        },
         "color-space": {
             "syntax": "<rectangular-color-space> | <polar-color-space> | <custom-color-space>"
-        },
-        "custom-color-space": {
-            "syntax": "<dashed-ident>"
         },
         "paint": {
             "comment": "used by SVG https://www.w3.org/TR/SVG/painting.html#SpecifyingPaint",
             "syntax": "none | <color> | <url> [ none | <color> ]? | context-fill | context-stroke"
-        },
-        "palette-identifier": {
-            "comment": "<palette-identifier> is parsed as a <dashed-ident> (https://drafts.csswg.org/css-fonts/#typedef-font-palette-palette-identifier)",
-            "syntax": "<dashed-ident>"
         },
         "right": {
             "comment": "missed; not sure we should add it, but no others except `shape` is using it so it's ok for now; https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect",
@@ -754,9 +703,6 @@
         },
         "forgiving-relative-selector-list": {
             "syntax": "<relative-real-selector-list>"
-        },
-        "selector-list": {
-            "syntax": "<complex-selector-list>"
         },
         "complex-real-selector-list": {
             "syntax": "<complex-real-selector>#"
@@ -796,13 +742,6 @@
         },
         "legacy-pseudo-element-selector": {
             "syntax": " ':' [before | after | first-line | first-letter]"
-        },
-        "single-animation-composition": {
-            "comment": "missed definition",
-            "references": [
-                "https://w3c.github.io/csswg-drafts/css-animations-2/#typedef-single-animation-composition"
-            ],
-            "syntax": "replace | add | accumulate"
         },
         "svg-length": {
             "comment": "All coordinates and lengths in SVG can be specified with or without a unit identifier",
@@ -859,39 +798,14 @@
         "colorspace-params": {
             "syntax": "[ <predefined-rgb-params> | <xyz-params>]"
         },
-        "predefined-rgb-params": {
-            "syntax": "<predefined-rgb> [ <number> | <percentage> | none ]{3}"
-        },
-        "predefined-rgb": {
-            "syntax": "srgb | srgb-linear | display-p3 | a98-rgb | prophoto-rgb | rec2020"
-        },
         "xyz-params": {
             "syntax": "<xyz-space> [ <number> | <percentage> | none ]{3}"
         },
         "xyz-space": {
             "syntax": "xyz | xyz-d50 | xyz-d65"
         },
-        "oklab()": {
-            "comment": "https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch",
-            "syntax": "oklab( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ / [<alpha-value> | none] ]? )"
-        },
-        "oklch()": {
-            "comment": "https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch",
-            "syntax": "oklch( [ <percentage> | <number> | none] [ <percentage> | <number> | none] [ <hue> | none] [ / [<alpha-value> | none] ]? )"
-        },
-        "offset-path": {
-            "syntax": "<ray()> | <url> | <basic-shape>"
-        },
         "basic-shape": {
             "syntax": "<inset()> | <xywh()> | <rect()> | <circle()> | <ellipse()> | <polygon()> | <path()>"
-        },
-        "rect()": {
-            "comment": "missed, https://drafts.csswg.org/css-shapes/#supported-basic-shapes",
-            "syntax": "rect( [ <length-percentage> | auto ]{4} [ round <'border-radius'> ]? )"
-        },
-        "xywh()": {
-            "comment": "missed, https://drafts.csswg.org/css-shapes/#supported-basic-shapes",
-            "syntax": "xywh( <length-percentage>{2} <length-percentage [0,∞]>{2} [ round <'border-radius'> ]? )"
         },
         "query-in-parens": {
             "comment": "missed, https://drafts.csswg.org/css-contain-3/#container-rule",
@@ -941,9 +855,6 @@
                 "https://drafts.csswg.org/css-anchor-position-1/#anchor-pos"
             ]
         },
-        "anchor-side": {
-            "syntax": "inside | outside | top | left | right | bottom | start | end | self-start | self-end | <percentage> | center"
-        },
         "anchor-size()": {
             "syntax": "anchor-size( [ <anchor-element> || <anchor-size> ]? , <length-percentage>? )",
             "comment": "missed",
@@ -951,20 +862,9 @@
                 "https://drafts.csswg.org/css-anchor-position-1/#funcdef-anchor-size"
             ]
         },
-        "anchor-size": {
-            "syntax": "width | height | block | inline | self-block | self-inline"
-        },
         "anchor-element": {
             "syntax": "<dashed-ident>",
             "comment": "missed, https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-element"
-        },
-        "try-size": {
-            "syntax": "most-width | most-height | most-block-size | most-inline-size",
-            "comment": "missed, https://drafts.csswg.org/css-anchor-position-1/#typedef-try-size"
-        },
-        "try-tactic": {
-            "syntax": "flip-block || flip-inline || flip-start",
-            "comment": "missed, https://drafts.csswg.org/css-anchor-position-1/#typedef-position-try-fallbacks-try-tactic"
         },
         "font-variant-css2": {
             "syntax": "normal | small-caps",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.12.2",
+        "mdn-data": "^2.18.0",
         "source-map-js": "^1.0.1"
       },
       "devDependencies": {
@@ -1660,9 +1660,10 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.18.0.tgz",
+      "integrity": "sha512-gtCy1yim/vpHF/tq3B4Z43x3zKWpYeb4IM3d/Mf4oMYcNuoXOYEaqtoFlLHw9zd7+WNN3jNh6/WXyUrD3OIiwQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3427,9 +3428,9 @@
       }
     },
     "mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.18.0.tgz",
+      "integrity": "sha512-gtCy1yim/vpHF/tq3B4Z43x3zKWpYeb4IM3d/Mf4oMYcNuoXOYEaqtoFlLHw9zd7+WNN3jNh6/WXyUrD3OIiwQ=="
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "prepublishOnly": "npm run lint-and-test && npm run build-and-test"
   },
   "dependencies": {
-    "mdn-data": "2.12.2",
+    "mdn-data": "^2.18.0",
     "source-map-js": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates CSS syntax to the latest definitions.

- Updates `mdn-data`
- Incorporate changes from:
  - https://github.com/csstree/csstree/pull/323
  - https://github.com/csstree/csstree/pull/324

I then ran `npm run review:syntax-patch` to remove any redundant entries in `data/patch.json`