### PR TITLE
fix: Remove `src` descriptor patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -386,10 +386,6 @@
             ],
             "syntax": "[ none | <dashed-ident> ]#"
         },
-        "src": {
-            "comment": "added @font-face's src property https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src",
-            "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#"
-        },
         "speak": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "auto | never | always"


### PR DESCRIPTION
it is a descriptor of `@font-face` at-rule, not a CSS property; so it should not be patched here