### PR TITLE
fix: Remove wrong `scroll-timeline` property patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -372,13 +372,6 @@
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<time> | none | x-weak | weak | medium | strong | x-strong"
         },
-        "scroll-timeline": {
-            "comment": "fix according to spec",
-            "references": [
-                "https://www.w3.org/TR/scroll-animations-1/#scroll-timeline-shorthand"
-            ],
-            "syntax": "[ <'scroll-timeline-name'> || <'scroll-timeline-axis'> ]#"
-        },
         "scroll-timeline-name": {
             "comment": "fix according to spec",
             "references": [


### PR DESCRIPTION
this patch is not correct: the spec's version and mdn-data's version is both `[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#`, while the patch's version is `[ <'scroll-timeline-name'> || <'scroll-timeline-axis'> ]#`

browsers implement as the spec defines

see https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-timeline and https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline