### PR TITLE
fix: Remove outdated `@font-face/unicode-range` descriptor patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -6,14 +6,6 @@
         "container": {
             "prelude": "[ <container-name> ]? <container-condition>"
         },
-        "font-face": {
-            "descriptors": {
-                "unicode-range": {
-                    "comment": "replaces <unicode-range>, an old production name",
-                    "syntax": "<urange>#"
-                }
-            }
-        },
         "nest": {
             "prelude": "<complex-selector-list>"
         },


### PR DESCRIPTION
the latest spec has update the syntax to `<unicode-range-token>#`

see https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range and https://drafts.csswg.org/css-fonts/#unicode-range-desc