### PR TITLE
Nested selector support

### DIFF
--- a/fixtures/ast/rule/nesting.json
+++ b/fixtures/ast/rule/nesting.json
@@ -589,9 +589,9 @@
             }
         }
     },
-    "don't parse nested rule when it not started with &": {
-        "source": ".foo{ .bar & { color: green; }; div:hover { color: red; } }",
-        "generate": ".foo{.bar & { color: green; };div:hover { color: red; }}",
+    "nested class selector": {
+        "source": "s{ p:v;.t { a:b } }",
+        "generate": "s{p:v;.t{a:b}}",
         "ast": {
             "type": "Rule",
             "prelude": {
@@ -601,8 +601,8 @@
                         "type": "Selector",
                         "children": [
                             {
-                                "type": "ClassSelector",
-                                "name": "foo"
+                                "type": "TypeSelector",
+                                "name": "s"
                             }
                         ]
                     }
@@ -612,16 +612,364 @@
                 "type": "Block",
                 "children": [
                     {
-                        "type": "Raw",
-                        "value": ".bar & { color: green; };"
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
                     },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "t"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested ID selector": {
+        "source": "s{ p:v; #t { a:b } }",
+        "generate": "s{p:v;#t{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
                     {
                         "type": "Declaration",
                         "important": false,
-                        "property": "div",
+                        "property": "p",
                         "value": {
-                            "type": "Raw",
-                            "value": "hover { color: red; }"
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "IdSelector",
+                                            "name": "t"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested attribute selector": {
+        "source": "s{ p:v; [data-foo] {  a: b}}",
+        "generate": "s{p:v;[data-foo]{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "AttributeSelector",
+                                            "name": {
+                                                "type": "Identifier",
+                                                "name": "data-foo"
+                                            },
+                                            "matcher": null,
+                                            "value": null,
+                                            "flags": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested universal selector": {
+        "source": "s{ p: v;*   {a:b }  }",
+        "generate": "s{p:v;*{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested pseudoclass selector": {
+        "source": "s { p:v; :hover { a: b } }",
+        "generate": "s{p:v;:hover{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "PseudoClassSelector",
+                                            "name": "hover",
+                                            "children": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
                         }
                     }
                 ]

--- a/lib/syntax/node/Block.js
+++ b/lib/syntax/node/Block.js
@@ -1,13 +1,25 @@
 import {
     WhiteSpace,
     Comment,
+    Delim,
     Semicolon,
+    Hash,
+    Colon,
     AtKeyword,
+    LeftSquareBracket,
     LeftCurlyBracket,
     RightCurlyBracket
 } from '../../tokenizer/index.js';
 
 const AMPERSAND = 0x0026;       // U+0026 AMPERSAND (&)
+const DOT = 0x002E;             // U+002E FULL STOP (.)
+const STAR = 0x002A;            // U+002A ASTERISK (*);
+
+const selectorStarts = new Set([
+    AMPERSAND,
+    DOT,
+    STAR
+]);
 
 function consumeRaw() {
     return this.Raw(null, true);
@@ -30,6 +42,12 @@ function consumeDeclaration() {
     }
 
     return node;
+}
+
+function isSelectorStart() {
+    return this.tokenType === Delim && selectorStarts.has(this.source.charCodeAt(this.tokenStart)) ||
+        this.tokenType === Hash || this.tokenType === LeftSquareBracket ||
+        this.tokenType === Colon;
 }
 
 export const name = 'Block';
@@ -65,7 +83,7 @@ export function parse(isStyleBlock) {
                 break;
 
             default:
-                if (isStyleBlock && this.isDelim(AMPERSAND))  {
+                if (isStyleBlock && isSelectorStart.call(this)) {
                     children.push(consumeRule.call(this));
                 } else {
                     children.push(consumer.call(this));


### PR DESCRIPTION
This pull request includes changes to improve the handling of nested selectors in the `Block` parsing logic and updates to the corresponding test fixtures.

**Note:** I couldn't quite figure out how to detect element selectors for nesting. All of the other selector types are supported. I could use some help figuring out the element selector piece.

Fixes #268

Improvements to nested selector handling:

* [`lib/syntax/node/Block.js`](diffhunk://#diff-ffb79eed874e2064a04053794a28808dd336ec60ee7fe40043e7058d17dd452aR4-R22): Added support for new selector types including `Delim`, `Hash`, `Colon`, and `LeftSquareBracket`, and introduced a new function `isSelectorStart` to improve detection of selector starts. [[1]](diffhunk://#diff-ffb79eed874e2064a04053794a28808dd336ec60ee7fe40043e7058d17dd452aR4-R22) [[2]](diffhunk://#diff-ffb79eed874e2064a04053794a28808dd336ec60ee7fe40043e7058d17dd452aR47-R52) [[3]](diffhunk://#diff-ffb79eed874e2064a04053794a28808dd336ec60ee7fe40043e7058d17dd452aL68-R86)

Updates to test fixtures:

* [`fixtures/ast/rule/nesting.json`](diffhunk://#diff-763ed205797f986e5e95a5ec912b2c055b67a5d5890e8e9b39bb66c53c86616cL592-R628): Updated test cases to include various nested selector scenarios such as nested class selectors, ID selectors, attribute selectors, universal selectors, and pseudo-class selectors. [[1]](diffhunk://#diff-763ed205797f986e5e95a5ec912b2c055b67a5d5890e8e9b39bb66c53c86616cL592-R628) [[2]](diffhunk://#diff-763ed205797f986e5e95a5ec912b2c055b67a5d5890e8e9b39bb66c53c86616cL605-R638) [[3]](diffhunk://#diff-763ed205797f986e5e95a5ec912b2c055b67a5d5890e8e9b39bb66c53c86616cL615-R972)