### PR TITLE
URL Encoding: support data globs

### DIFF
--- a/lib/__tests/decode-encode.js
+++ b/lib/__tests/decode-encode.js
@@ -137,7 +137,8 @@ describe('decode/encode', () => {
                 '"\'() \\': 'url(\\"\\\'\\(\\)\\ \\\\)',
                 '\u0008': 'url(\\8)',
                 '1 b': 'url(1\\ b)',
-                '1\n b': 'url(1\\a\\ b)'
+                '1\n b': 'url(1\\a\\ b)',
+                "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>": `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' fill='%2328303d'><polygon points='0,0 10,0 5,5'/></svg>")`
             };
 
             forEachTest(tests, url.encode);

--- a/lib/utils/url.js
+++ b/lib/utils/url.js
@@ -67,6 +67,12 @@ export function decode(str) {
 export function encode(str) {
     let encoded = '';
     let wsBeforeHexIsNeeded = false;
+    let isDataUrl = false;
+
+    // Check if the string is a data URL
+    if (str.startsWith('data:')) {
+        isDataUrl = true;
+    }
 
     for (let i = 0; i < str.length; i++) {
         const code = str.charCodeAt(i);
@@ -86,10 +92,9 @@ export function encode(str) {
             continue;
         }
 
-        if (code === SPACE ||
+        if ((!isDataUrl && ( code === SPACE || code === APOSTROPHE)) || // data URL globs are expected to have spaces and single quotes unescaped.
             code === REVERSE_SOLIDUS ||
             code === QUOTATION_MARK ||
-            code === APOSTROPHE ||
             code === LEFTPARENTHESIS ||
             code === RIGHTPARENTHESIS) {
             encoded += '\\' + str.charAt(i);
@@ -104,5 +109,10 @@ export function encode(str) {
         }
     }
 
+    if (isDataUrl) {
+        return 'url("' + encoded + '")';
+    }
+
     return 'url(' + encoded + ')';
+
 }


### PR DESCRIPTION
Fixes #340

The `url` field within CSS accepts `data` globs that will contain spaces and single-quotes very often. To keep things simple, this proposes to determine if an URL begins with `data`. If it does, allow for spaces and single-quotes and wrap the URL in double-quotes on return.

This could be expanded to detect if a space or single-quote is used and double-quote in those cases as well, though this PR attempts to only address the broken situation with as few changes to existing, working values.
