### PR TITLE
feat: Add support for math functions

### DIFF
--- a/fixtures/definition-syntax-match/generic.json
+++ b/fixtures/definition-syntax-match/generic.json
@@ -596,17 +596,12 @@
             "round(to-zero, 1px, 2px)",
             "mod(1px, 2px)",
             "rem(1px, 2px)",
-            "sin(45deg)",
-            "cos(45deg)",
-            "tan(45deg)",
             "asin(0.5)",
             "acos(0.5)",
             "atan(1)",
             "atan2(1px, 2px)",
             "hypot(3px, 4px)",
-            "abs(-1px)",
-            "sign(-1px)"
-
+            "abs(-1px)"
         ],
         "invalid": [
             "-ms-calc(1px + 1%)",
@@ -655,7 +650,8 @@
             "tan(45deg)",
             "pow(2, 3)",
             "sqrt(16)",
-            "log(100)"
+            "log(100)",
+            "sign(-1px)"
         ],
         "invalid": [
             "asin(1)",

--- a/lib/lexer/generic.js
+++ b/lib/lexer/generic.js
@@ -58,8 +58,8 @@ const steppedValueFunctionNames = [
     'rem('
 ];
 
-// Trigonometrical functions that return a <number> or <angle> depending on input
-const trigNumberOrAngleFunctionNames = [
+// Trigonometrical functions that return a <number>
+const trigNumberFunctionNames = [
     'sin(',
     'cos(',
     'tan('
@@ -73,12 +73,13 @@ const trigAngleFunctionNames = [
     'atan2('
 ];
 
-// Exponential functions that return a <number>
-const expNumberFunctionNames = [
+// Other functions that return a <number>
+const otherNumberFunctionNames = [
     'pow(',
     'sqrt(',
     'log(',
-    'exp('
+    'exp(',
+    'sign('
 ];
 
 // Exponential functions that return a <number> or <dimension> or <percentage>
@@ -88,16 +89,15 @@ const expNumberDimensionPercentageFunctionNames = [
 
 // Return the same type as the input
 const signFunctionNames = [
-    'abs(',
-    'sign('
+    'abs('
 ];
 
 const numberFunctionNames = [
     ...calcFunctionNames,
     ...comparisonFunctionNames,
     ...steppedValueFunctionNames,
-    ...trigNumberOrAngleFunctionNames,
-    ...expNumberFunctionNames,
+    ...trigNumberFunctionNames,
+    ...otherNumberFunctionNames,
     ...expNumberDimensionPercentageFunctionNames,
     ...signFunctionNames
 ];
@@ -115,7 +115,6 @@ const dimensionFunctionNames = [
     ...comparisonFunctionNames,
     ...steppedValueFunctionNames,
     ...trigAngleFunctionNames,
-    ...trigNumberOrAngleFunctionNames,
     ...expNumberDimensionPercentageFunctionNames,
     ...signFunctionNames
 ];


### PR DESCRIPTION
This PR updates the logic used to implement `calc()` so that it works for all math functions. 

The math functions themselves are divided based on the type of data they return and so I had to modify which math functions are allowed for which types of values.

fixes https://github.com/csstree/csstree/issues/338