### PR TITLE
fix: support percentage values in fill-opacity property

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -248,9 +248,10 @@
         "fill-opacity": {
             "comment": "added SVG property",
             "references": [
+                "https://developer.mozilla.org/en-US/docs/Web/CSS/fill-opacity",
                 "https://www.w3.org/TR/SVG/painting.html#FillProperty"
             ],
-            "syntax": "<number-zero-one>"
+            "syntax": "<number-zero-one> | <percentage>"
         },
         "filter": {
             "comment": "extend with IE legacy syntaxes",


### PR DESCRIPTION
Fix `fill-opacity` property to accept percentage values.

Resolves Stylelint validation error when using `100%` with `fill-opacity` property.