### PR TITLE
feat: Support @font-feature-values

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -6,8 +6,20 @@
         "container": {
             "prelude": "[ <container-name> ]? <container-condition>"
         },
-        "nest": {
-            "prelude": "<complex-selector-list>"
+        "font-face": {
+            "descriptors": {
+                "unicode-range": {
+                    "comment": "replaces <unicode-range>, an old production name",
+                    "syntax": "<urange>#"
+                }
+            }
+        },
+        "font-features-values": {
+            "comment": "The features values syntax is defined in https://www.w3.org/TR/css-fonts-4/#at-ruledef-font-feature-values",
+            "prelude": "[<string> | <custom-ident>]+",
+            "descriptors": {
+                "font-display": "auto | block | swap | fallback | optional"
+            }
         },
         "scope": {
             "prelude": "[ ( <scope-start> ) ]? [ to ( <scope-end> ) ]?"
@@ -202,6 +214,10 @@
         "behavior": {
             "comment": "added old IE property https://msdn.microsoft.com/en-us/library/ms530723(v=vs.85).aspx",
             "syntax": "<url>+"
+        },
+        "container-type": {
+            "comment": "https://www.w3.org/TR/css-contain-3/#propdef-container-type",
+            "syntax": "normal || [ size | inline-size ]"
         },
         "cue": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",

--- a/fixtures/ast/atrule/atrule/font-feature-values.json
+++ b/fixtures/ast/atrule/atrule/font-feature-values.json
@@ -1,0 +1,352 @@
+{
+  "with character-variant and styleset": {
+    "source": "@font-feature-values InterVariable{@character-variant{cv01:1;cv02:2;cv03:3;alt-1:1;open-4:2;open-6:3}@styleset{ss01:1;ss02:2;ss03:3;open-digits:1;disambiguation:2;round-quotes-and-commas:3}}",
+    "ast": {
+      "type": "Atrule",
+      "name": "font-feature-values",
+      "prelude": {
+        "type": "AtrulePrelude",
+        "children": [
+          {
+            "type": "Identifier",
+            "name": "InterVariable"
+          }
+        ]
+      },
+      "block": {
+        "type": "Block",
+        "children": [
+          {
+            "type": "Atrule",
+            "name": "character-variant",
+            "prelude": null,
+            "block": {
+              "type": "Block",
+              "children": [
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "cv01",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "cv02",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "2"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "cv03",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "3"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "alt-1",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "open-4",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "2"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "open-6",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "3"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "Atrule",
+            "name": "styleset",
+            "prelude": null,
+            "block": {
+              "type": "Block",
+              "children": [
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "ss01",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "ss02",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "2"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "ss03",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "3"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "open-digits",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "disambiguation",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "2"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "round-quotes-and-commas",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "3"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "with all feature types": {
+    "source": "@font-feature-values \"Another Font\"{@annotation{circled:1}@ornaments{fleuron:1}@stylistic{alt-a:1}@swash{swash1:1}@historical-forms{hist:1}}",
+    "ast": {
+      "type": "Atrule",
+      "name": "font-feature-values",
+      "prelude": {
+        "type": "AtrulePrelude",
+        "children": [
+          {
+            "type": "String",
+            "value": "Another Font"
+          }
+        ]
+      },
+      "block": {
+        "type": "Block",
+        "children": [
+          {
+            "type": "Atrule",
+            "name": "annotation",
+            "prelude": null,
+            "block": {
+              "type": "Block",
+              "children": [
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "circled",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "Atrule",
+            "name": "ornaments",
+            "prelude": null,
+            "block": {
+              "type": "Block",
+              "children": [
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "fleuron",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "Atrule",
+            "name": "stylistic",
+            "prelude": null,
+            "block": {
+              "type": "Block",
+              "children": [
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "alt-a",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "Atrule",
+            "name": "swash",
+            "prelude": null,
+            "block": {
+              "type": "Block",
+              "children": [
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "swash1",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "type": "Atrule",
+            "name": "historical-forms",
+            "prelude": null,
+            "block": {
+              "type": "Block",
+              "children": [
+                {
+                  "type": "Declaration",
+                  "important": false,
+                  "property": "hist",
+                  "value": {
+                    "type": "Value",
+                    "children": [
+                      {
+                        "type": "Number",
+                        "value": "1"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds support for `@font-feature-values`:
https://developer.mozilla.org/en-US/docs/Web/CSS/@font-feature-values