### PR TITLE
Add patch for `overflow-block` and `overflow-inline`

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -330,6 +330,14 @@
             "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y",
             "syntax": "| <-non-standard-overflow>"
         },
+        "overflow-block": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y",
+            "syntax": "| <-non-standard-overflow>"
+        },
+        "overflow-inline": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x",
+            "syntax": "| <-non-standard-overflow>"
+        },
         "pause": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<'pause-before'> <'pause-after'>?"


### PR DESCRIPTION
Follow up after: https://github.com/csstree/csstree/pull/323

These legacy keywords are also supported in logical properties:

```
CSS.supports('overflow-y: overlay')
// true
CSS.supports('overflow-inline: overlay')
// true
```