### PR TITLE
chore: stop listing Svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ CSSTree is a tool set for CSS: [fast](https://github.com/postcss/benchmark) deta
 
 ## Projects using CSSTree
 
-- [Svelte](https://github.com/sveltejs/svelte) – Cybernetically enhanced web apps
 - [SVGO](https://github.com/svg/svgo) – Node.js tool for optimizing SVG files
 - [CSSO](https://github.com/css/csso) – CSS minifier with structural optimizations
 - [NativeScript](https://github.com/NativeScript/NativeScript) – NativeScript empowers you to access native APIs from JavaScript directly


### PR DESCRIPTION
Svelte stopped using css-tree in [Svelte 5](https://github.com/sveltejs/svelte/commit/fe8a9ce31d5fb662b3953b318621ea364992e014), replaced by an internal parser in `packages/svelte/src/compiler/phases/1-parse/read/style.js`