### PR TITLE
Remove legacy IE syntax from `filter`

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -269,10 +269,6 @@
             ],
             "syntax": "<number-zero-one> | <percentage>"
         },
-        "filter": {
-            "comment": "extend with IE legacy syntaxes",
-            "syntax": "| <-ms-filter-function-list>"
-        },
         "font": {
             "comment": "align with font-4, fix <'font-family'>#, add non standard fonts",
             "references": [
@@ -554,22 +550,6 @@
         "-webkit-mask-box-repeat": {
             "comment": "missed; https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-mask-box-image",
             "syntax": "repeat | stretch | round"
-        },
-        "-ms-filter-function-list": {
-            "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-            "syntax": "<-ms-filter-function>+"
-        },
-        "-ms-filter-function": {
-            "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-            "syntax": "<-ms-filter-function-progid> | <-ms-filter-function-legacy>"
-        },
-        "-ms-filter-function-progid": {
-            "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-            "syntax": "'progid:' [ <ident-token> '.' ]* [ <ident-token> | <function-token> <any-value>? ) ]"
-        },
-        "-ms-filter-function-legacy": {
-            "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
-            "syntax": "<ident-token> | <function-token> <any-value>? )"
         },
         "age": {
             "comment": "https://www.w3.org/TR/css3-speech/#voice-family",

--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -118,6 +118,17 @@ describe('Lexer#matchProperty()', () => {
         });
     });
 
+    describe('light-dark(1px, 2px) should be invalid for all properties', () => {
+        for (const property of Object.keys(lexer.properties)) {
+            it(property, () => {
+                const match = lexer.matchProperty(property, 'light-dark(1px, 2px)');
+
+                assert.strictEqual(match.matched, null, `light-dark(1px, 2px) should NOT match "${property}"`);
+                assert.ok(match.error.name === 'SyntaxMatchError' || match.error.name === 'Error', `light-dark(1px, 2px) should be invalid for "${property}"`);
+            });
+        }
+    });
+
     forEachTest((testType, testState, name, lexer, property, value, syntax) => {
         switch (testType) {
             case 'valid':


### PR DESCRIPTION
This blames back to https://github.com/csstree/csstree/commit/6015263dee6782874a146aabb2f14ee660a5f534.

As far as I can tell this is unsupported in all modern browsers (as in
`-ms-filter` was deprecated in IE9 and removed in IE10) but I did not test to verify that. This surfaces as a bug in stylelint
https://github.com/stylelint/stylelint/issues/9148, where
`light-dark()` with arguments that are _not_ colors are not caught as an
error for `filter`. Add a test for that case, since it should error for all properties.

Some docs I found:
- https://learn.microsoft.com/en-us/previous-versions/ms530752(v=vs.85)
- https://learn.microsoft.com/en-us/archive/blogs/ie/the-css-corner-using-filters-in-ie8

https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter is currently a 404

Unsure if you want the test or not, or if this is the appropriate location, it's creation was AI-assisted so I am not sure if it uses the API correctly but it does run and did reproduce the error, and was fixed by the removal of the syntax-extension in `data/patch.json`