### PR TITLE
Fix parse error for whitespace-only functional pseudo arguments (fixes #283)

### DIFF
--- a/fixtures/ast/selector/functional-pseudo/is.json
+++ b/fixtures/ast/selector/functional-pseudo/is.json
@@ -91,6 +91,23 @@
             ]
         }
     },
+    "empty argument": {
+        "source": ":is()",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "is",
+            "children": []
+        }
+    },
+    "empty argument with whitespace": {
+        "source": ":is( )",
+        "generate": ":is()",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "is",
+            "children": []
+        }
+    },
     "should be case insensitive": {
         "source": ":HaS(.a,.b)",
         "ast": {

--- a/fixtures/ast/selector/functional-pseudo/not.json
+++ b/fixtures/ast/selector/functional-pseudo/not.json
@@ -91,6 +91,32 @@
             ]
         }
     },
+    "empty argument": {
+        "source": ":not()",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "not",
+            "children": []
+        }
+    },
+    "empty argument with whitespace": {
+        "source": ":not( )",
+        "generate": ":not()",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "not",
+            "children": []
+        }
+    },
+    "comment-only argument": {
+        "source": ":not(/* comment */)",
+        "generate": ":not()",
+        "ast": {
+            "type": "PseudoClassSelector",
+            "name": "not",
+            "children": []
+        }
+    },
     "should be case insensitive": {
         "source": ":NoT(.a,.b)",
         "ast": {

--- a/fixtures/ast/selector/functional-pseudo/slotted.json
+++ b/fixtures/ast/selector/functional-pseudo/slotted.json
@@ -33,6 +33,15 @@
             "children": []
         }
     },
+    "empty argument with whitespace": {
+        "source": "::slotted( )",
+        "generate": "::slotted()",
+        "ast": {
+            "type": "PseudoElementSelector",
+            "name": "slotted",
+            "children": []
+        }
+    },
     "spaces around selector": {
         "source": "::slotted(  .a.b  )",
         "generate": "::slotted(.a.b)",

--- a/lib/syntax/node/PseudoClassSelector.js
+++ b/lib/syntax/node/PseudoClassSelector.js
@@ -27,6 +27,7 @@ export function parse() {
         nameLowerCase = name.toLowerCase();
 
         if (this.lookupNonWSType(0) == RightParenthesis) {
+            this.skipSC();
             children = this.createList();
         } else if (hasOwnProperty.call(this.pseudo, nameLowerCase)) {
             this.skipSC();

--- a/lib/syntax/node/PseudoElementSelector.js
+++ b/lib/syntax/node/PseudoElementSelector.js
@@ -27,6 +27,7 @@ export function parse() {
         nameLowerCase = name.toLowerCase();
 
         if (this.lookupNonWSType(0) == RightParenthesis) {
+            this.skipSC();
             children = this.createList();
         } else if (hasOwnProperty.call(this.pseudo, nameLowerCase)) {
             this.skipSC();


### PR DESCRIPTION
`parse(':not( )', { context: 'selector' })` throws `")" is expected`, and so do `:is( )`, `:has( )`, `::slotted( )` and friends when the parens hold only whitespace. Drop the space and `:not()`/`:is()` parse fine, so the whitespace is the whole difference.

The empty-parens branch spots the closing paren with `lookupNonWSType(0)` (which looks past whitespace), so `:not( )` lands there correctly, but it never consumed the space before `eat(RightParenthesis)`. Adding `this.skipSC()` (the same call the branch just below makes) fixes it. Fixtures for `:not`, `:is`, `::slotted` and a comment-only case throw on current code and pass with the change.

Two calls for you: the issue title is about empty `:not()` throwing, which per your comment is intended, so this only covers the whitespace/comment-only case. And I applied the same one-liner to `PseudoElementSelector` since it's the identical bug in the sibling node, happy to drop that half.

fixes #283